### PR TITLE
Refactor headers; NFC

### DIFF
--- a/src/ast/arithplus.cpp
+++ b/src/ast/arithplus.cpp
@@ -1,10 +1,6 @@
 #include "ast/arithplus.h"
 
-#include "ast/identifier.h"
-#include "ast/integer.h"
-#include "ast/lambda.h"
-#include "ast/values.h"
-#include "ast/void.h"
+#include "exprnode_inc.h"
 
 using namespace nir;
 

--- a/src/ast/definevalues.cpp
+++ b/src/ast/definevalues.cpp
@@ -2,11 +2,7 @@
 
 #include <utility>
 
-#include "ast/arithplus.h"
-#include "ast/integer.h"
-#include "ast/lambda.h"
-#include "ast/values.h"
-#include "ast/void.h"
+#include "toplevelnode_inc.h"
 
 using namespace nir;
 

--- a/src/ast/lambda.cpp
+++ b/src/ast/lambda.cpp
@@ -4,12 +4,8 @@
 #include <memory>
 #include <vector>
 
-#include "ast/arithplus.h"
 #include "ast/formal.h"
-#include "ast/identifier.h"
-#include "ast/integer.h"
-#include "ast/values.h"
-#include "ast/void.h"
+#include "exprnode_inc.h"
 
 using namespace nir;
 

--- a/src/ast/linklet.cpp
+++ b/src/ast/linklet.cpp
@@ -2,13 +2,7 @@
 
 #include <memory>
 
-#include "ast/arithplus.h"
-#include "ast/definevalues.h"
-#include "ast/identifier.h"
-#include "ast/integer.h"
-#include "ast/lambda.h"
-#include "ast/values.h"
-#include "ast/void.h"
+#include "toplevelnode_inc.h"
 
 using namespace nir;
 

--- a/src/ast/values.cpp
+++ b/src/ast/values.cpp
@@ -1,10 +1,6 @@
 #include "ast/values.h"
 
-#include "ast/arithplus.h"
-#include "ast/identifier.h"
-#include "ast/integer.h"
-#include "ast/lambda.h"
-#include "ast/void.h"
+#include "exprnode_inc.h"
 
 using namespace nir;
 

--- a/src/dumper.cpp
+++ b/src/dumper.cpp
@@ -3,15 +3,9 @@
 #include <gmp.h>
 #include <iostream>
 
-#include "ast/arithplus.h"
-#include "ast/definevalues.h"
 #include "ast/formal.h"
-#include "ast/identifier.h"
-#include "ast/integer.h"
-#include "ast/lambda.h"
 #include "ast/linklet.h"
-#include "ast/values.h"
-#include "ast/void.h"
+#include "toplevelnode_inc.h"
 
 void Dumper::operator()(nir::Identifier const &Id) {
   std::wcout << Id.getName();

--- a/src/include/exprnode_inc.h
+++ b/src/include/exprnode_inc.h
@@ -1,0 +1,9 @@
+#pragma once
+
+// This headers is just a utility header to include all headers that
+// are expr nodes.
+// See README.md in the current directory for more information.
+#include "ast/arithplus.h"
+#include "ast/identifier.h"
+#include "ast/lambda.h"
+#include "valuenode_inc.h"

--- a/src/include/toplevelnode_inc.h
+++ b/src/include/toplevelnode_inc.h
@@ -1,0 +1,7 @@
+#pragma once
+
+// This headers is just a utility header to include all headers that
+// are expr nodes.
+// See README.md in the current directory for more information.
+#include "ast/definevalues.h"
+#include "exprnode_inc.h"

--- a/src/include/valuenode_inc.h
+++ b/src/include/valuenode_inc.h
@@ -1,0 +1,8 @@
+#pragma once
+
+// This headers is just a utility header to include all headers that
+// are value nodes.
+// See README.md in the current directory for more information.
+#include "ast/integer.h"
+#include "ast/values.h"
+#include "ast/void.h"

--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -6,14 +6,8 @@
 #include <plog/Log.h>
 #include <variant>
 
-#include "ast/arithplus.h"
-#include "ast/definevalues.h"
-#include "ast/identifier.h"
-#include "ast/integer.h"
-#include "ast/lambda.h"
 #include "ast/linklet.h"
-#include "ast/values.h"
-#include "ast/void.h"
+#include "toplevelnode_inc.h"
 #include "utils/overloaded.h"
 #include "utils/upcast.h"
 #include "valuenode.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,17 +9,11 @@
 #include <plog/Log.h>
 #include <variant>
 
-#include "ast/arithplus.h"
-#include "ast/definevalues.h"
-#include "ast/identifier.h"
-#include "ast/integer.h"
-#include "ast/lambda.h"
-#include "ast/values.h"
-#include "ast/void.h"
 #include "config.h"
 #include "dumper.h"
 #include "interpreter.h"
 #include "parse.h"
+#include "toplevelnode_inc.h"
 #include "valuenode.h"
 
 namespace fs = std::filesystem;

--- a/src/parser/parse.cpp
+++ b/src/parser/parse.cpp
@@ -16,17 +16,10 @@
 #include <utility>
 #include <vector>
 
-#include "ast/arithplus.h"
-#include "ast/definevalues.h"
-#include "ast/identifier.h"
-#include "ast/integer.h"
-#include "ast/lambda.h"
-#include "ast/linklet.h"
-#include "ast/values.h"
-#include "ast/void.h"
 #include "astnode.h"
 #include "exprnode.h"
 #include "parse.h"
+#include "toplevelnode_inc.h"
 #include "utils/idpool.h"
 #include "utils/upcast.h"
 


### PR DESCRIPTION
Some headers were always being included together.
This commit creates a couple of `_inc.h` files which are just sets of include files to simplify file header inclusion when adding new AST nodes.