### PR TITLE
Implement let-values

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,6 +47,7 @@ add_llvm_executable(norac
         environment.cpp
         utils/idpool.cpp
         utils/upcast.cpp
+        utils/downcast.cpp
         parser/parse.cpp
         interpreter/interpreter.cpp
         ast/arithplus.cpp
@@ -61,5 +62,6 @@ add_llvm_executable(norac
         ast/application.cpp
         ast/setbang.cpp
         ast/ifcond.cpp
+        ast/letvalues.cpp
 )
 target_link_libraries(norac PRIVATE ${LIBS})

--- a/src/ast/letvalues.cpp
+++ b/src/ast/letvalues.cpp
@@ -1,0 +1,38 @@
+#include "ast/letvalues.h"
+
+#include <utility>
+
+#include "exprnode_inc.h"
+
+using namespace nir;
+
+LetValues::LetValues(const LetValues &DV) {
+  for (auto const &Id : DV.Ids) {
+    Ids.emplace_back(Id);
+  }
+  for (auto const &Expr : DV.Exprs) {
+    Exprs.emplace_back(std::make_unique<nir::ExprNode>(*Expr));
+  }
+  for (auto const &Expr : DV.Body) {
+    Body.emplace_back(std::make_unique<nir::ExprNode>(*Expr));
+  }
+}
+
+void LetValues::appendBinding(std::vector<Identifier> &&Ids,
+                              std::unique_ptr<ExprNode> Expr) {
+  this->Ids.emplace_back(std::move(Ids));
+  this->Exprs.emplace_back(std::move(Expr));
+}
+
+void LetValues::appendBody(std::unique_ptr<ExprNode> Expr) {
+  Body.emplace_back(std::move(Expr));
+}
+nir::LetValues::IdRange LetValues::getBindingIds(size_t Idx) const {
+  assert(Idx < Ids.size());
+  return IdRange{Ids[Idx]};
+}
+ExprNode const &LetValues::getBindingExpr(size_t Idx) const {
+  return *Exprs[Idx];
+}
+ExprNode const &LetValues::getBodyExpr(size_t Idx) const { return *Body[Idx]; }
+size_t nir::LetValues::exprsCount() const { return Exprs.size(); }

--- a/src/exprnode.cpp
+++ b/src/exprnode.cpp
@@ -45,3 +45,7 @@ std::unique_ptr<nir::TLNode>
 nir::ToTopLevelNode::operator()(nir::BooleanLiteral &&Bool) {
   return std::make_unique<nir::TLNode>(std::move(Bool));
 }
+std::unique_ptr<nir::TLNode>
+nir::ToTopLevelNode::operator()(nir::LetValues &&LV) {
+  return std::make_unique<nir::TLNode>(std::move(LV));
+}

--- a/src/include/README.md
+++ b/src/include/README.md
@@ -18,6 +18,7 @@ ASTNodes
       |- +Application
       |- +SetBang
       |- +IfCond
+      |- +LetValues
       |- Value
          |- +Integer
          |- +Values

--- a/src/include/ast/definevalues.h
+++ b/src/include/ast/definevalues.h
@@ -27,6 +27,7 @@ public:
         : BeginIt(Ids.cbegin()), EndIt(Ids.cend()) {}
     [[nodiscard]] auto begin() const { return BeginIt; }
     [[nodiscard]] auto end() const { return EndIt; }
+    const Identifier &operator[](size_t Idx) const { return *(BeginIt + Idx); }
 
   private:
     std::vector<Identifier>::const_iterator BeginIt, EndIt;

--- a/src/include/ast/letvalues.h
+++ b/src/include/ast/letvalues.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <cassert>
+#include <memory>
+#include <vector>
+
+#include "../exprnode.h"
+#include "identifier.h"
+
+namespace nir {
+
+class LetValues {
+public:
+  LetValues() = default;
+  LetValues(const LetValues &DV);
+  LetValues(LetValues &&DV) = default;
+  LetValues &operator=(const LetValues &DV) = delete;
+  LetValues &operator=(LetValues &&DV) = default;
+  ~LetValues() = default;
+
+  // View over the Ids
+  // FIXME: we should be able to use C++20 view_interface here
+  // although my initial attempt failed.
+  class IdRange {
+  public:
+    IdRange() = delete;
+    IdRange(const std::vector<Identifier> &Ids)
+        : BeginIt(Ids.cbegin()), EndIt(Ids.cend()) {}
+    [[nodiscard]] auto begin() const { return BeginIt; }
+    [[nodiscard]] auto end() const { return EndIt; }
+    [[nodiscard]] Identifier const &operator[](size_t Idx) const {
+      return *(BeginIt + Idx);
+    }
+
+  private:
+    std::vector<Identifier>::const_iterator BeginIt, EndIt;
+  };
+
+  IdRange getBindingIds(size_t Idx) const;
+  ExprNode const &getBindingExpr(size_t Idx) const;
+  ExprNode const &getBodyExpr(size_t Idx) const;
+
+  void appendBinding(std::vector<Identifier> &&Ids,
+                     std::unique_ptr<ExprNode> Expr);
+  void appendBody(std::unique_ptr<ExprNode> Expr);
+
+  size_t bindingCount() const {
+    assert(Ids.size() == Exprs.size());
+    return Ids.size();
+  }
+  size_t idsCount() const { return Ids.size(); }
+  size_t exprsCount() const;
+  size_t bodyCount() const { return Body.size(); }
+
+private:
+  std::vector<std::vector<Identifier>> Ids;
+  std::vector<std::unique_ptr<ExprNode>> Exprs;
+  std::vector<std::unique_ptr<ExprNode>> Body;
+};
+
+}; // namespace nir

--- a/src/include/astnode.h
+++ b/src/include/astnode.h
@@ -18,9 +18,11 @@ class Application;
 class SetBang;
 class IfCond;
 class BooleanLiteral;
+class LetValues;
 
-using ASTNode = std::variant<Linklet, Identifier, Integer, ArithPlus,
-                             DefineValues, Values, Void, Lambda, Begin, List,
-                             Application, SetBang, IfCond, BooleanLiteral>;
+using ASTNode =
+    std::variant<Linklet, Identifier, Integer, ArithPlus, DefineValues, Values,
+                 Void, Lambda, Begin, List, Application, SetBang, IfCond,
+                 BooleanLiteral, LetValues>;
 
 }; // namespace nir

--- a/src/include/dumper.h
+++ b/src/include/dumper.h
@@ -22,4 +22,5 @@ struct Dumper {
   void operator()(nir::SetBang const &SB);
   void operator()(nir::IfCond const &If);
   void operator()(nir::BooleanLiteral const &Bool);
+  void operator()(nir::LetValues const &LV);
 };

--- a/src/include/exprnode.h
+++ b/src/include/exprnode.h
@@ -19,10 +19,11 @@ class Application;
 class SetBang;
 class IfCond;
 class BooleanLiteral;
+class LetValues;
 
 using ExprNode =
     std::variant<Integer, Identifier, Values, ArithPlus, Void, Lambda, Begin,
-                 List, Application, SetBang, IfCond, BooleanLiteral>;
+                 List, Application, SetBang, IfCond, BooleanLiteral, LetValues>;
 
 struct ToTopLevelNode {
   std::unique_ptr<TLNode> operator()(nir::Identifier &&Id);
@@ -37,6 +38,7 @@ struct ToTopLevelNode {
   std::unique_ptr<TLNode> operator()(nir::SetBang &&SB);
   std::unique_ptr<TLNode> operator()(nir::IfCond &&If);
   std::unique_ptr<TLNode> operator()(nir::BooleanLiteral &&Bool);
+  std::unique_ptr<TLNode> operator()(nir::LetValues &&LV);
 };
 
 }; // namespace nir

--- a/src/include/exprnode_inc.h
+++ b/src/include/exprnode_inc.h
@@ -8,5 +8,6 @@
 #include "ast/begin.h"
 #include "ast/identifier.h"
 #include "ast/ifcond.h"
+#include "ast/letvalues.h"
 #include "ast/setbang.h"
 #include "valuenode_inc.h"

--- a/src/include/interpreter.h
+++ b/src/include/interpreter.h
@@ -17,6 +17,8 @@
 
 class Interpreter {
 public:
+  Interpreter();
+
   std::unique_ptr<nir::ValueNode> operator()(nir::Identifier const &Id);
   std::unique_ptr<nir::ValueNode> operator()(nir::Integer const &Int);
   std::unique_ptr<nir::ValueNode> operator()(nir::Linklet const &Linklet);
@@ -31,6 +33,7 @@ public:
   std::unique_ptr<nir::ValueNode> operator()(nir::SetBang const &SB);
   std::unique_ptr<nir::ValueNode> operator()(nir::IfCond const &If);
   std::unique_ptr<nir::ValueNode> operator()(nir::BooleanLiteral const &Bool);
+  std::unique_ptr<nir::ValueNode> operator()(nir::LetValues const &LV);
 
 private:
   // Environment map for identifiers.

--- a/src/include/toplevelnode.h
+++ b/src/include/toplevelnode.h
@@ -17,9 +17,10 @@ class Application;
 class SetBang;
 class IfCond;
 class BooleanLiteral;
+class LetValues;
 
 using TLNode = std::variant<Identifier, Integer, ArithPlus, DefineValues,
                             Values, Void, Lambda, Begin, List, Application,
-                            SetBang, IfCond, BooleanLiteral>;
+                            SetBang, IfCond, BooleanLiteral, LetValues>;
 
 }; // namespace nir

--- a/src/include/utils/downcast.h
+++ b/src/include/utils/downcast.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <memory>
+
+#include "exprnode.h"
+#include "valuenode.h"
+
+std::unique_ptr<nir::ValueNode>
+downcastExprToValueNode(std::unique_ptr<nir::ExprNode> &&E);

--- a/src/utils/downcast.cpp
+++ b/src/utils/downcast.cpp
@@ -1,0 +1,38 @@
+#include "utils/downcast.h"
+
+#include <iostream>
+#include <memory>
+#include <variant>
+
+#include "exprnode_inc.h"
+#include "utils/overloaded.h"
+#include "valuenode_inc.h"
+
+std::unique_ptr<nir::ValueNode>
+downcastExprToValueNode(std::unique_ptr<nir::ExprNode> &&E) {
+  nir::ExprNode *Expr = E.release();
+  std::unique_ptr<nir::ValueNode> Val = std::visit(
+      overloaded{
+          [](nir::Void const &V) {
+            return std::make_unique<nir::ValueNode>(V);
+          },
+          [](nir::Integer const &I) {
+            return std::make_unique<nir::ValueNode>(I);
+          },
+          [](nir::Values const &V) {
+            return std::make_unique<nir::ValueNode>(V);
+          },
+          [](nir::Lambda const &L) {
+            return std::make_unique<nir::ValueNode>(L);
+          },
+          [](nir::BooleanLiteral const &Bool) {
+            return std::make_unique<nir::ValueNode>(Bool);
+          },
+          [](auto const &Err) {
+            std::cerr << "Error: Cannot downcast expression that's not a value."
+                      << std::endl;
+            return std::unique_ptr<nir::ValueNode>();
+          }},
+      *Expr);
+  return Val;
+}

--- a/test/integration/define-values2.rkt
+++ b/test/integration/define-values2.rkt
@@ -1,0 +1,5 @@
+;; RUN: norac %s | FileCheck %s
+;;      CHECK: 3
+(linklet () () 
+  (define-values (x y) (values 1 2))
+  (+ x y))

--- a/test/integration/let-values.rkt
+++ b/test/integration/let-values.rkt
@@ -1,0 +1,5 @@
+;; RUN: norac %s | FileCheck %s
+;; CHECK: 3
+(linklet () ()
+  (let-values (((x y) (values 1 2)))
+    (+ x y)))

--- a/test/integration/let-values1.rkt
+++ b/test/integration/let-values1.rkt
@@ -1,0 +1,5 @@
+;; RUN: norac %s | FileCheck %s
+;; CHECK: 6
+(linklet () ()
+  (let-values (((x y z) (values 1 2 3)))
+    (+ x (+ y z))))

--- a/test/integration/let-values2.rkt
+++ b/test/integration/let-values2.rkt
@@ -1,0 +1,6 @@
+;; RUN: norac %s | FileCheck %s
+;; CHECK: 30
+(linklet () ()
+  (let-values (((x) (values 10)))
+    (let-values (((y) (values 20)))
+      (+ x y))))

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -28,8 +28,10 @@ add_executable(test_parse
   ${PROJECT_SOURCE_DIR}/src/ast/application.cpp
   ${PROJECT_SOURCE_DIR}/src/ast/setbang.cpp
   ${PROJECT_SOURCE_DIR}/src/ast/ifcond.cpp
+  ${PROJECT_SOURCE_DIR}/src/ast/letvalues.cpp
   ${PROJECT_SOURCE_DIR}/src/utils/idpool.cpp
   ${PROJECT_SOURCE_DIR}/src/utils/upcast.cpp
+  ${PROJECT_SOURCE_DIR}/src/utils/downcast.cpp
   ${PROJECT_SOURCE_DIR}/src/exprnode.cpp
   ${PROJECT_SOURCE_DIR}/src/valuenode.cpp
 )


### PR DESCRIPTION
This is a rather large change because to implement let-values, we fixed a couple of things along the way.

* `define-values` should not create a new environment. Just adds to the current one.
* as a consequence of the previous point, we need to add an empty env at interpreter construction time.
* implement a downcast function from expr to value as that is needed around a few places.
* add more implementations for dumper.

Fixes #7