### PR TITLE
Change clangd arguments

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,24 +1,32 @@
 {
-    "clangd.checkUpdates": true,
-    "doxdocgen.generic.authorEmail": "p@ocmatos.com",
-    "doxdocgen.generic.authorName": "Paulo Matos",
-    "C_Cpp.codeAnalysis.clangTidy.enabled": false,
-    "C_Cpp.codeAnalysis.runAutomatically": false,
-    "cmake.configureEnvironment": {},
-    "cmake.configureArgs": [
-        "-G Ninja",
-        "-DCMAKE_PREFIX_PATH=/home/pmatos/dev/llvm-project/build/lib/cmake",
-        "-DWITH_UBSAN=True",
-        "-DWITH_ASAN=True"
-    ],
-    "C_Cpp.intelliSenseEngine": "disabled",
-    "C_Cpp.autocomplete": "disabled",
-    "C_Cpp.clang_format_sortIncludes": true,
-    "editor.defaultFormatter": null,
-    "[cpp]": {
-        "editor.defaultFormatter": "xaver.clang-format",
-        "editor.formatOnSave": true
-    },
-    "cSpell.enabled": false,
-    "editor.tabSize": 2,
+  "clangd.checkUpdates": true,
+  "clangd.arguments": [
+    "-log=verbose",
+    "-pretty",
+    "--background-index",
+    "--completion-style=detailed",
+    "--compile-commands-dir=${workspaceFolder}/build",
+    "--header-insertion=never"
+  ],
+  "doxdocgen.generic.authorEmail": "p@ocmatos.com",
+  "doxdocgen.generic.authorName": "Paulo Matos",
+  "C_Cpp.codeAnalysis.clangTidy.enabled": false,
+  "C_Cpp.codeAnalysis.runAutomatically": false,
+  "cmake.configureEnvironment": {},
+  "cmake.configureArgs": [
+    "-G Ninja",
+    "-DCMAKE_PREFIX_PATH=/home/pmatos/dev/llvm-project/build/lib/cmake",
+    "-DWITH_UBSAN=True",
+    "-DWITH_ASAN=True"
+  ],
+  "C_Cpp.intelliSenseEngine": "disabled",
+  "C_Cpp.autocomplete": "disabled",
+  "C_Cpp.clang_format_sortIncludes": true,
+  "editor.defaultFormatter": null,
+  "[cpp]": {
+    "editor.defaultFormatter": "xaver.clang-format",
+    "editor.formatOnSave": true
+  },
+  "cSpell.enabled": false,
+  "editor.tabSize": 2,
 }


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> #### What Changed
> Added
> - clangd.arguments
> - editor.formatOnSave
> #### Testing
> Test that clangd is now using the specified arguments and that code formatting is applied on save.
> #### Reasoning
> Improve development experience by enabling verbose logging and detailed completion style for clangd, and formatting code on save.
</details>