### PR TITLE
Modernize toolchain, build, and CI (LLVM 22, C++23, MLIR opt-in)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,2 @@
 BasedOnStyle: LLVM
+Standard: c++20

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{cpp,cc,h,hpp}]
+indent_style = space
+indent_size = 2
+
+[*.td]
+indent_style = space
+indent_size = 2
+
+[*.{yml,yaml,json}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+# The extracted Racket expander is a generated artifact; leave it untouched.
+[expander/expander.rktl]
+trim_trailing_whitespace = false
+insert_final_newline = false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,20 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
+# Dependabot version updates.
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
+#
+# The only tracked ecosystem is GitHub Actions: the workflow actions are pinned
+# to commit SHAs, and Dependabot keeps those pins (and the version comments)
+# current. The C++/CMake dependencies (LLVM, MLIR, GMP) are provided by the
+# system toolchain and Catch2 is fetched by CMake FetchContent, so there is no
+# package manifest for Dependabot to track.
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,4 +1,5 @@
 name: Codecov
+
 on:
   push:
     branches:
@@ -6,41 +7,66 @@ on:
   pull_request:
     branches:
       - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codecov-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  LLVM_VERSION: "22"
+  CMAKE_PREFIX_PATH: /usr/lib/llvm-22
+  CC: gcc-14
+  CXX: g++-14
+
 jobs:
-  test-with-coverage:
-    runs-on: ubuntu-latest
+  coverage:
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
-      - name: Install dependencies
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install LLVM ${{ env.LLVM_VERSION }}
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh "$LLVM_VERSION"
+
+      - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y lcov cmake gcc g++ clang-15 llvm-15-dev llvm-15-tools mlir-15-tools libmlir-15-dev git ninja-build python3-pip
-      - name: Install FileCheck alternative
-        run: sudo update-alternatives --install /usr/bin/FileCheck FileCheck /usr/bin/FileCheck-15 1
+          sudo apt-get install -y ninja-build libgmp-dev lcov gcc-14 g++-14 \
+            "llvm-${LLVM_VERSION}-dev" "llvm-${LLVM_VERSION}-tools" python3-pip
+          echo "/usr/lib/llvm-${LLVM_VERSION}/bin" >> "$GITHUB_PATH"
+
       - name: Install lit
-        run: pip3 install lit
+        run: pip3 install --break-system-packages lit
+
       - name: Configure
-        run: |
-          mkdir build
-          cd build
-          cmake -G Ninja -DCMAKE_BUILD_TYPE=Coverage -DCMAKE_PREFIX_PATH="/usr/lib/llvm-15/cmake;/usr/lib/llvm-15/lib/cmake/mlir/" -DCMAKE_VERBOSE_MAKEFILE=1 -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ ..
+        run: cmake --preset coverage
+
       - name: Build
-        working-directory: ./build
-        run: ninja norac
-      - name: Integration Testing
-        working-directory: ./build
-        run: bin/nora-lit ../test/integration -v
-      - name: Run lcov
-        working-directory: ./build
+        run: cmake --build --preset coverage
+
+      - name: Run tests
+        run: ctest --test-dir build/coverage --output-on-failure
+
+      - name: Collect coverage
         run: |
-          lcov --capture --directory . --output-file coverage.info
-          lcov --remove coverage.info '/usr/*' --output-file coverage.info
+          lcov --capture --directory build/coverage --output-file coverage.info \
+            --gcov-tool gcov-14 \
+            --ignore-errors mismatch,gcov,source,unused,empty,inconsistent,negative
+          lcov --remove coverage.info '/usr/*' '*/build/*/_deps/*' \
+            --output-file coverage.info \
+            --ignore-errors unused,empty
           lcov --list coverage.info
+
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           flags: integration
           verbose: true
-          file: ./build/coverage.info
+          files: ./coverage.info

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,29 +1,27 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
     - cron: '40 2 * * 1'
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  LLVM_VERSION: "22"
+  CMAKE_PREFIX_PATH: /usr/lib/llvm-22
+  CC: clang-22
+  CXX: clang++-22
 
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read
@@ -32,49 +30,36 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'cpp' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Use only 'java' to analyze code written in Java, Kotlin or both
-        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+        language: ['c-cpp']
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y cmake clang-15 llvm-15-dev llvm-15-tools mlir-15-tools libmlir-15-dev git ninja-build python3-pip
+      - name: Install LLVM ${{ env.LLVM_VERSION }}
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh "$LLVM_VERSION"
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build libgmp-dev "clang-${LLVM_VERSION}" \
+            "llvm-${LLVM_VERSION}-dev" "llvm-${LLVM_VERSION}-tools"
 
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: manual
 
-    - name: Configure
-      run: cmake -G Ninja -DCMAKE_PREFIX_PATH="/usr/lib/llvm-15/cmake;/usr/lib/llvm-15/lib/cmake/mlir/" -DCMAKE_VERBOSE_MAKEFILE=1 -DCMAKE_C_COMPILER=clang-15 -DCMAKE_CXX_COMPILER=clang++-15 .
-    - name: Build
-      run: ninja norac
+      - name: Build
+        run: |
+          cmake --preset release
+          cmake --build --preset release --target norac
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #     echo "Run, Build Application using script"
-    #     ./location_of_script_within_repo/buildscript.sh
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -2,20 +2,31 @@ name: "ClangFormat"
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: format-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  LLVM_VERSION: "22"
+
 jobs:
   clang-format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 5
-      - name: Install dependencies
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install clang-format ${{ env.LLVM_VERSION }}
         run: |
-          sudo apt-get update
-          sudo apt-get install -y git clang-format-15
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh "$LLVM_VERSION"
+          sudo apt-get install -y "clang-format-${LLVM_VERSION}"
+
       - name: Check formatting
-        working-directory: ${{ github.workspace }}
         run: |
-          pwd
-          ls -la
-          git clang-format-15 HEAD~1
+          mapfile -t files < <(git ls-files '*.cpp' '*.h' '*.hpp' '*.cc')
+          "clang-format-${LLVM_VERSION}" -i "${files[@]}"
+          git diff --exit-code

--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -12,42 +12,57 @@ on:
       - '**.def'
       - '**.h.in'
 
+permissions:
+  contents: read
+
+concurrency:
+  group: scan-build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  LLVM_VERSION: "22"
+  CMAKE_PREFIX_PATH: /usr/lib/llvm-22
+
 jobs:
   analyze:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Install LLVM ${{ env.LLVM_VERSION }}
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh "$LLVM_VERSION"
 
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake clang-15 clang-tools-15 llvm-15-dev llvm-15-tools mlir-15-tools libmlir-15-dev git ninja-build python3-pip
+          sudo apt-get install -y ninja-build libgmp-dev "clang-${LLVM_VERSION}" \
+            "clang-tools-${LLVM_VERSION}" "llvm-${LLVM_VERSION}-dev" "llvm-${LLVM_VERSION}-tools"
+          echo "/usr/lib/llvm-${LLVM_VERSION}/bin" >> "$GITHUB_PATH"
 
-      - name: Install FileCheck alternative
-        run: | 
-          sudo update-alternatives --install /usr/bin/FileCheck FileCheck /usr/bin/FileCheck-15 1
-          sudo update-alternatives --install /usr/bin/scan-build scan-build /usr/bin/scan-build-15 1
-
-      - name: Run scan-build
+      - name: Analyze base (main)
         run: |
-          git fetch origin main
-          git checkout main
-          mkdir build
-          cd build
-          cmake -G "Unix Makefiles" -DCMAKE_PREFIX_PATH="/usr/lib/llvm-15/cmake;/usr/lib/llvm-15/lib/cmake/mlir/" -DCMAKE_VERBOSE_MAKEFILE=1 -DCMAKE_C_COMPILER=clang-15 -DCMAKE_CXX_COMPILER=clang++-15 ..
-          scan-build -o ../base-analysis make
-          cd ..
-          rm -Rf build
-          git checkout ${{ github.sha }}
-          mkdir build
-          cd build
-          cmake -G "Unix Makefiles" -DCMAKE_PREFIX_PATH="/usr/lib/llvm-15/cmake;/usr/lib/llvm-15/lib/cmake/mlir/" -DCMAKE_VERBOSE_MAKEFILE=1 -DCMAKE_C_COMPILER=clang-15 -DCMAKE_CXX_COMPILER=clang++-15 ..
-          scan-build -o ../pr-analysis make
+          git checkout "origin/${GITHUB_BASE_REF:-main}"
+          scan-build --use-cc="clang-${LLVM_VERSION}" --use-c++="clang++-${LLVM_VERSION}" \
+            -o base-analysis cmake -G Ninja -S . -B build-base -DCMAKE_BUILD_TYPE=Release
+          scan-build --use-cc="clang-${LLVM_VERSION}" --use-c++="clang++-${LLVM_VERSION}" \
+            -o base-analysis cmake --build build-base --target norac
+
+      - name: Analyze pull request head
+        run: |
+          git checkout "${{ github.sha }}"
+          scan-build --use-cc="clang-${LLVM_VERSION}" --use-c++="clang++-${LLVM_VERSION}" \
+            -o pr-analysis cmake -G Ninja -S . -B build-pr -DCMAKE_BUILD_TYPE=Release
+          scan-build --use-cc="clang-${LLVM_VERSION}" --use-c++="clang++-${LLVM_VERSION}" \
+            -o pr-analysis cmake --build build-pr --target norac
 
       - name: Compare scan-build results
         run: |
-          python3 -m pip install beautifulsoup4
+          python3 -m pip install --break-system-packages beautifulsoup4
           python3 scripts/compare_scan_build_reports.py base-analysis pr-analysis
-

--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -46,13 +46,24 @@ jobs:
             "clang-tools-${LLVM_VERSION}" "llvm-${LLVM_VERSION}-dev" "llvm-${LLVM_VERSION}-tools"
           echo "/usr/lib/llvm-${LLVM_VERSION}/bin" >> "$GITHUB_PATH"
 
-      - name: Analyze base (main)
+      # Best-effort baseline. If the base tree fails to configure/build with
+      # this toolchain (e.g. it predates the modernization and still requires
+      # MLIR), skip the baseline instead of failing the job; the compare step
+      # then reports the PR's findings without a differential. Once a
+      # modernized commit lands on the base branch this resolves itself.
+      - name: Analyze base (${{ github.base_ref || 'main' }})
         run: |
           git checkout "origin/${GITHUB_BASE_REF:-main}"
-          scan-build --use-cc="clang-${LLVM_VERSION}" --use-c++="clang++-${LLVM_VERSION}" \
-            -o base-analysis cmake -G Ninja -S . -B build-base -DCMAKE_BUILD_TYPE=Release
-          scan-build --use-cc="clang-${LLVM_VERSION}" --use-c++="clang++-${LLVM_VERSION}" \
-            -o base-analysis cmake --build build-base --target norac
+          if scan-build --use-cc="clang-${LLVM_VERSION}" --use-c++="clang++-${LLVM_VERSION}" \
+               -o base-analysis cmake -G Ninja -S . -B build-base -DCMAKE_BUILD_TYPE=Release \
+             && scan-build --use-cc="clang-${LLVM_VERSION}" --use-c++="clang++-${LLVM_VERSION}" \
+               -o base-analysis cmake --build build-base --target norac; then
+            # Keep the directory even when scan-build prunes it for zero findings.
+            mkdir -p base-analysis
+          else
+            echo "::warning::Base tree (${GITHUB_BASE_REF:-main}) failed to build with this toolchain; skipping the differential baseline."
+            rm -rf base-analysis
+          fi
 
       - name: Analyze pull request head
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,66 +2,100 @@ name: Test
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: test-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  LLVM_VERSION: "22"
+  CMAKE_PREFIX_PATH: /usr/lib/llvm-22
+
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         compiler: [clang, gcc]
-        mode: [Debug, Release]
+        preset: [debug, release]
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Install dependencies
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install LLVM ${{ env.LLVM_VERSION }}
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh "$LLVM_VERSION"
+
+      - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake git ninja-build python3-pip
-          if [ ${{ matrix.compiler }} = "clang" ]; then
-            sudo apt-get install -y clang-15 llvm-15-dev llvm-15-tools mlir-15-tools libmlir-15-dev
-            echo "CC=clang-15" >> $GITHUB_ENV
-            echo "CXX=clang++-15" >> $GITHUB_ENV
-          elif [ ${{ matrix.compiler }} = "gcc" ]; then
-            sudo apt-get install -y gcc-12 g++-12 llvm-15-dev llvm-15-tools mlir-15-tools libmlir-15-dev
-            echo "CC=gcc-12" >> $GITHUB_ENV
-            echo "CXX=g++-12" >> $GITHUB_ENV
+          sudo apt-get install -y ninja-build libgmp-dev \
+            "llvm-${LLVM_VERSION}-dev" "llvm-${LLVM_VERSION}-tools" python3-pip
+          if [ "${{ matrix.compiler }}" = "clang" ]; then
+            sudo apt-get install -y "clang-${LLVM_VERSION}"
+            echo "CC=clang-${LLVM_VERSION}" >> "$GITHUB_ENV"
+            echo "CXX=clang++-${LLVM_VERSION}" >> "$GITHUB_ENV"
+          else
+            sudo apt-get install -y gcc-14 g++-14
+            echo "CC=gcc-14" >> "$GITHUB_ENV"
+            echo "CXX=g++-14" >> "$GITHUB_ENV"
           fi
-          sudo update-alternatives --install /usr/bin/FileCheck FileCheck /usr/bin/FileCheck-15 1
-      - name: Install lit
-        run: pip3 install lit
-      - name: Configure
-        run: |
-          mkdir build
-          cd build
-          cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.mode }} -DCMAKE_PREFIX_PATH="/usr/lib/llvm-15/cmake;/usr/lib/llvm-15/lib/cmake/mlir/" -DCMAKE_VERBOSE_MAKEFILE=1 -DCMAKE_C_COMPILER=${{ env.CC }} -DCMAKE_CXX_COMPILER=${{ env.CXX }} ..
-      - name: Build
-        working-directory: ./build
-        run: ninja
-      - name: Test
-        working-directory: ./build
-        run: ninja test
+          # Make FileCheck and friends discoverable for the lit test suite.
+          echo "/usr/lib/llvm-${LLVM_VERSION}/bin" >> "$GITHUB_PATH"
 
-  ubsan-test:
+      - name: Install lit
+        run: pip3 install --break-system-packages lit
+
+      - name: Configure
+        run: cmake --preset ${{ matrix.preset }}
+
+      - name: Build
+        run: cmake --build --preset ${{ matrix.preset }}
+
+      - name: Test
+        run: ctest --preset ${{ matrix.preset }}
+
+  sanitizers:
     needs: test
-    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        preset: [asan, ubsan]
+    runs-on: ubuntu-24.04
+    env:
+      CC: clang-22
+      CXX: clang++-22
     steps:
-      - uses: actions/checkout@v3
-      - name: Install dependencies
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install LLVM ${{ env.LLVM_VERSION }}
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh "$LLVM_VERSION"
+
+      - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake git ninja-build python3-pip
-          sudo apt-get install -y clang-15 llvm-15-dev llvm-15-tools mlir-15-tools libmlir-15-dev
-          sudo update-alternatives --install /usr/bin/FileCheck FileCheck /usr/bin/FileCheck-15 1
+          sudo apt-get install -y ninja-build libgmp-dev \
+            "clang-${LLVM_VERSION}" "llvm-${LLVM_VERSION}-dev" \
+            "llvm-${LLVM_VERSION}-tools" python3-pip
+          echo "/usr/lib/llvm-${LLVM_VERSION}/bin" >> "$GITHUB_PATH"
+
       - name: Install lit
-        run: pip3 install lit
-      - name: Configure with UBSan
-        run: |
-          mkdir build
-          cd build
-          cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH="/usr/lib/llvm-15/cmake;/usr/lib/llvm-15/lib/cmake/mlir/" -DCMAKE_VERBOSE_MAKEFILE=1 -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DWITH_UBSAN=True ..
-      - name: Build with UBSan
-        working-directory: ./build
-        run: ninja
-      - name: Test with UBSan
-        working-directory: ./build
-        run: bin/nora-lit ../test/integration -v
+        run: pip3 install --break-system-packages lit
+
+      - name: Configure
+        run: cmake --preset ${{ matrix.preset }}
+
+      - name: Build
+        run: cmake --build --preset ${{ matrix.preset }}
+
+      - name: Test
+        run: ctest --preset ${{ matrix.preset }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+# Pre-commit hooks for local hygiene. See https://pre-commit.com
+#
+#   pip install pre-commit   # or: pipx install pre-commit
+#   pre-commit install       # enable the git hook
+#   pre-commit run --all-files
+#
+# The extracted Racket expander is a generated artifact and is excluded.
+exclude: '^expander/expander\.rktl$'
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+        args: ["--markdown-linebreak-ext=md"]
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args: ["--fix=lf"]
+      - id: check-yaml
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: ["--maxkb=1024"]
+
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v22.1.5
+    hooks:
+      - id: clang-format
+        types_or: [c++, c]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# NORA — agent guide
+
+NORA is an experimental Racket implementation in **C++23** with an **LLVM 22**
+backend. Today `norac` parses a linklet (a Racket [Fully Expanded
+Program](https://docs.racket-lang.org/reference/syntax-model.html#%28part._fully-expanded%29))
+and interprets it; the LLVM/MLIR compilation backend is future work. See
+`README.md` for the project vision and roadmap.
+
+## Build, run, test
+
+The build is driven by [`CMakePresets.json`](CMakePresets.json). The default
+build depends only on **LLVM and GMP** — no MLIR.
+
+```
+cmake --preset debug         # configure (also: release, asan, ubsan, coverage, mlir)
+cmake --build --preset debug # build -> build/debug/bin/{norac,nora-lit}
+ctest --preset debug         # unit (Catch2) + integration (lit/FileCheck) tests
+```
+
+- Run the interpreter: `./build/debug/bin/norac test/integration/arithplus.rkt`
+- Integration tests only: `./build/debug/bin/nora-lit test/integration -v`
+- The code is **warning-clean on both GCC and Clang** and built with
+  warnings-as-errors (`-DCMAKE_COMPILE_WARNING_AS_ERROR=OFF` to relax locally).
+
+## Layout
+
+- `src/` — the interpreter. Pipeline: `SourceStream` → `Lex` → `Parse` →
+  `AST` (`ast.cpp`/`ast.h`) → `Interpreter` (an `ASTVisitor`) → `Runtime`
+  values. Supporting pieces: `Environment`, `ASTRuntime`, `AnalysisFreeVars`,
+  `IdPool`, `UTF8`. `main.cpp` wires it together with LLVM `cl::opt`.
+- `src/include/Casting.h` — LLVM-style RTTI (`isa`/`cast`/`dyn_cast`) for AST
+  nodes; `ASTVisitor.h` — the visitor interface.
+- `src/mlir/` + `src/include/nir/` — the **experimental NIR MLIR dialect**.
+  This is an empty scaffold, **opt-in** behind `-DNORA_ENABLE_MLIR=ON` (the
+  `mlir` preset), and **not used by the interpreter**. Do not add MLIR to the
+  default build path.
+- `test/unit/` — Catch2 tests (`test_parse.cpp`); Catch2 is fetched by CMake.
+- `test/integration/` — `.rkt` files run through `lit` + `FileCheck`.
+- `expander/expander.rktl` — a large generated Racket artifact; do not edit.
+
+## Conventions
+
+- Formatting: `clang-format` (LLVM base style; `.clang-format`). CI fails on any
+  drift, so run it before committing.
+- Linting: `clang-tidy` (`.clang-tidy`).
+- Optional local hooks: `pre-commit install` (see `.pre-commit-config.yaml`).
+
+## Adding an integration test
+
+Create `test/integration/<name>.rkt`:
+
+```
+;; RUN: norac %s | FileCheck %s
+;; CHECK: <expected output>
+(linklet () () <expression>)
+```
+
+`lit` substitutes `norac` with the built binary; `FileCheck` must be on `PATH`.
+
+## Toolchain notes
+
+- Requires CMake >= 3.24, Ninja, LLVM 22 (matching Clang, or GCC >= 13), and
+  GMP with its C++ bindings (`gmpxx`).
+- CI (`.github/workflows/`) installs LLVM 22 from apt.llvm.org, builds via the
+  presets on Ubuntu 24.04, and pins actions to commit SHAs.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,29 +1,30 @@
-# Version set according the the cmake versions available in Ubuntu/Bionic:
-# https://packages.ubuntu.com/bionic/cmake
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.24)
 
 project(nora LANGUAGES C CXX VERSION 102)
 include(GNUInstallDirs)
 include(CTest)
 include(FetchContent)
 
-if(POLICY CMP0077)
-  cmake_policy(SET CMP0077 NEW)
-endif()
-
-if(POLICY CMP0116)
-  cmake_policy(SET CMP0116 NEW)
-endif()
-
 set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE ON)
 
 # The C++ standard whose features are required to build nora.
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
-set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g -Werror")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3 -flto -Werror")
-set(CMAKE_CXX_FLAGS_MINSIZEREL "-Oz -flto -Werror")
+# The NIR MLIR dialect is experimental and not used by the interpreter yet, so
+# MLIR is opt-in. The default build depends only on LLVM + GMP.
+option(NORA_ENABLE_MLIR "Build the experimental NIR MLIR dialect (requires MLIR)" OFF)
+
+# Treat compiler warnings as errors by default (CMake >= 3.24). The code is
+# warning-clean on GCC and Clang; disable with -DCMAKE_COMPILE_WARNING_AS_ERROR=OFF
+# for exploratory local builds.
+option(NORA_WERROR "Treat compiler warnings as errors" ON)
+set(CMAKE_COMPILE_WARNING_AS_ERROR ${NORA_WERROR})
+
+set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -flto")
+set(CMAKE_CXX_FLAGS_MINSIZEREL "-Oz -flto")
 
 # Add new build type COVERAGE
 message("* Adding build type COVERAGE...")
@@ -60,24 +61,6 @@ message("* Current build type is : ${CMAKE_BUILD_TYPE}")
 set(CMAKE_BUILD_WITH_INSTALL_NAME_DIR ON)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
-if(NOT CMAKE_BUILD_TYPE)
-  message(STATUS "No build type selected, default to Release")
-  set(CMAKE_BUILD_TYPE "Release")
-endif()
-
-# FIXME: there are some warnings in GCC - so disable Werror
-#        for now.
-# From cmake 2.24 onwards we can use CMAKE_COMPILE_WARNING_AS_ERROR
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  set(FLAGS_TO_REMOVE "-Werror")
-  foreach(TYPE "" "_DEBUG" "_RELEASE" "_RELWITHDEBINFO" "_MINSIZEREL" "_COVERAGE")
-    set(CURRENT_FLAG_VAR "CMAKE_CXX_FLAGS${TYPE}")
-    if(${CURRENT_FLAG_VAR} MATCHES ${FLAGS_TO_REMOVE})
-        string(REPLACE ${FLAGS_TO_REMOVE} "" ${CURRENT_FLAG_VAR} "${${CURRENT_FLAG_VAR}}")
-    endif()
-  endforeach()
-endif()
 
 # For git users, attempt to generate a more useful version string
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
@@ -116,25 +99,26 @@ find_package(LLVM REQUIRED CONFIG)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 
-find_package(MLIR REQUIRED CONFIG)
-message(STATUS "Using MILRConfig.cmake in: ${MLIR_DIR}")
-
 set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/bin)
 set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/lib)
-set(MLIR_BINARY_DIR ${CMAKE_BINARY_DIR})
 
-list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
 list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
 include(TableGen)
 include(AddLLVM)
-include(AddMLIR)
 include(HandleLLVMOptions)
 
 include_directories(${LLVM_INCLUDE_DIRS})
 separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
 add_definitions(${LLVM_DEFINITIONS_LIST})
 
-include_directories(${MLIR_INCLUDE_DIRS})
+if(NORA_ENABLE_MLIR)
+  find_package(MLIR REQUIRED CONFIG)
+  message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
+  set(MLIR_BINARY_DIR ${CMAKE_BINARY_DIR})
+  list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
+  include(AddMLIR)
+  include_directories(${MLIR_INCLUDE_DIRS})
+endif()
 
 # Configure src
 add_subdirectory(src)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,101 @@
+{
+  "version": 5,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 24,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "cacheVariables": {
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
+    },
+    {
+      "name": "debug",
+      "displayName": "Debug",
+      "description": "Debug build of the interpreter (no MLIR)",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "release",
+      "displayName": "Release",
+      "description": "Optimized (-O3 -flto) release build",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "asan",
+      "displayName": "Debug + AddressSanitizer",
+      "inherits": "debug",
+      "cacheVariables": {
+        "WITH_ASAN": "ON"
+      }
+    },
+    {
+      "name": "ubsan",
+      "displayName": "Debug + UndefinedBehaviorSanitizer",
+      "inherits": "debug",
+      "cacheVariables": {
+        "WITH_UBSAN": "ON"
+      }
+    },
+    {
+      "name": "coverage",
+      "displayName": "Coverage",
+      "description": "Debug build instrumented for gcov/lcov coverage",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Coverage"
+      }
+    },
+    {
+      "name": "mlir",
+      "displayName": "Debug + experimental NIR MLIR dialect",
+      "description": "Requires MLIR to be installed",
+      "inherits": "debug",
+      "cacheVariables": {
+        "NORA_ENABLE_MLIR": "ON"
+      }
+    }
+  ],
+  "buildPresets": [
+    { "name": "debug", "configurePreset": "debug" },
+    { "name": "release", "configurePreset": "release" },
+    { "name": "asan", "configurePreset": "asan" },
+    { "name": "ubsan", "configurePreset": "ubsan" },
+    { "name": "coverage", "configurePreset": "coverage" },
+    { "name": "mlir", "configurePreset": "mlir" }
+  ],
+  "testPresets": [
+    {
+      "name": "debug",
+      "configurePreset": "debug",
+      "output": { "outputOnFailure": true }
+    },
+    {
+      "name": "release",
+      "configurePreset": "release",
+      "output": { "outputOnFailure": true }
+    },
+    {
+      "name": "asan",
+      "configurePreset": "asan",
+      "output": { "outputOnFailure": true }
+    },
+    {
+      "name": "ubsan",
+      "configurePreset": "ubsan",
+      "output": { "outputOnFailure": true }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -4,21 +4,53 @@ NORA is an experimental Racket implementation written with a LLVM backend.
 
 # Building & Testing
 
-There's not much happening right now, but the right way to try this is by running a `cmake` configuration build and running the unit and integration tests.
+## Prerequisites
+
+- [CMake](https://cmake.org) >= 3.24 and [Ninja](https://ninja-build.org)
+- [LLVM](https://llvm.org) 22, built with either its matching Clang or GCC >= 13
+- [GMP](https://gmplib.org) including the C++ bindings (`gmpxx`)
+- Python 3 with [lit](https://pypi.org/project/lit/) for the integration tests
+
+The default build depends only on LLVM and GMP. The experimental NIR MLIR
+dialect is **opt-in** and is not needed to build or run the interpreter — see
+[The NIR MLIR dialect](#the-nir-mlir-dialect) below.
+
+## Build and run the tests
+
+The project ships [CMake presets](CMakePresets.json):
 
 ```
 $ git clone https://github.com/pmatos/nora
-$ cd nora 
-$ mkdir build && cd build
-$ cmake -G Ninja ..
-$ ninja test
+$ cd nora
+$ cmake --preset debug
+$ cmake --build --preset debug
+$ ctest --preset debug
 ```
 
-All tests should pass. If you do modifications, you can run the testing workflow with [act](https://github.com/nektos/act) inside the nora directory with the following command line:
+Other presets are available: `release`, `asan`, `ubsan`, `coverage`, and
+`mlir` (builds the opt-in NIR dialect and requires MLIR to be installed).
+
+Run the interpreter on a linklet directly:
 
 ```
-$ act -P ubuntu-22.04=ghcr.io/catthehacker/ubuntu:act-22.04 -j test
+$ ./build/debug/bin/norac test/integration/arithplus.rkt
+2
 ```
+
+If you modify the project you can run the CI test workflow locally with
+[act](https://github.com/nektos/act):
+
+```
+$ act -P ubuntu-24.04=ghcr.io/catthehacker/ubuntu:act-24.04 -j test
+```
+
+## The NIR MLIR dialect
+
+NORA's planned compiler backend will lower to an MLIR dialect called NIR (Nora
+IR; see the [roadmap](#compilation-of-racket)). It is currently an empty
+scaffold that the interpreter does not use, so MLIR is opt-in and off by
+default. Enable it with `cmake --preset mlir` or `-DNORA_ENABLE_MLIR=ON` once
+MLIR is installed.
 
 # Linklets
 

--- a/scripts/compare_scan_build_reports.py
+++ b/scripts/compare_scan_build_reports.py
@@ -19,6 +19,18 @@ if __name__ == "__main__":
     base_analysis_dir = sys.argv[1]
     pr_analysis_dir = sys.argv[2]
 
+    # An absent base directory means the base tree could not be built with the
+    # current toolchain (e.g. it predates a toolchain modernization), so there
+    # is no baseline to diff against. Skip the differential rather than flag
+    # every PR finding as new. An empty-but-present directory means the base
+    # built cleanly with zero findings, so the differential still runs.
+    if not os.path.isdir(base_analysis_dir):
+        print(
+            f"Base analysis '{base_analysis_dir}' is unavailable "
+            "(base tree did not build); skipping differential comparison."
+        )
+        sys.exit(0)
+
     base_errors = parse_reports(base_analysis_dir)
     pr_errors = parse_reports(pr_analysis_dir)
     new_errors = pr_errors - base_errors

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,17 +2,20 @@ include_directories(include)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/include/)
 
 add_subdirectory(include)
-add_subdirectory(mlir)
 
-get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
-get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
-set(LIBS
-        ${dialect_libs}
-        ${conversion_libs}
-        gmp
-        MLIROptLib
-        nirLib
-)
+set(LIBS gmp)
+
+if(NORA_ENABLE_MLIR)
+        add_subdirectory(mlir)
+        get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+        get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
+        list(APPEND LIBS
+                ${dialect_libs}
+                ${conversion_libs}
+                MLIROptLib
+                nirLib
+        )
+endif()
 
 add_llvm_executable(norac
         AnalysisFreeVars.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,11 @@ if(NORA_ENABLE_MLIR)
         )
 endif()
 
+# norac uses LLVM Support APIs directly (cl, InitLLVM, MemoryBuffer,
+# raw_ostream). Link the Support component explicitly so the default
+# (MLIR-off) build also links on LLVM installs without the libLLVM dylib.
+set(LLVM_LINK_COMPONENTS Support)
+
 add_llvm_executable(norac
         AnalysisFreeVars.cpp
         AST.cpp

--- a/src/Parse.cpp
+++ b/src/Parse.cpp
@@ -4,8 +4,6 @@
 #include "IdPool.h"
 #include "Lex.h"
 
-#include "mlir/IR/Diagnostics.h"
-
 #include <array>
 #include <cassert>
 #include <codecvt>
@@ -21,7 +19,6 @@
 #include <regex>
 #include <string>
 #include <string_view>
-#include <unicode/unistr.h>
 #include <utility>
 #include <vector>
 

--- a/src/SourceStream.cpp
+++ b/src/SourceStream.cpp
@@ -36,7 +36,7 @@ bool SourceStream::searchRegex(const char *Regex, std::cmatch &CM) const {
 }
 
 bool SourceStream::isPrefix(const char *Str) const {
-  return Contents.drop_front(Position).startswith(Str);
+  return Contents.drop_front(Position).starts_with(Str);
 }
 
 char SourceStream::peekChar(size_t N) const {

--- a/src/include/AST.h
+++ b/src/include/AST.h
@@ -356,7 +356,7 @@ public:
 
 class IdentifierFormal : public Formal {
 public:
-  IdentifierFormal(const Identifier &I) : I(I){};
+  IdentifierFormal(const Identifier &I) : I(I) {};
   IdentifierFormal(const IdentifierFormal &Other) = default;
   IdentifierFormal(IdentifierFormal &&Other) = default;
   IdentifierFormal &operator=(const IdentifierFormal &Other) = delete;

--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -1,1 +1,3 @@
-add_subdirectory(nir)
+if(NORA_ENABLE_MLIR)
+  add_subdirectory(nir)
+endif()

--- a/src/include/nora.h
+++ b/src/include/nora.h
@@ -1,12 +1,11 @@
 #pragma once
 
 #ifdef __cplusplus
-extern "C"
-{
+extern "C" {
 #endif
 
-  void nora_init();
-  
+void nora_init();
+
 #ifdef __cplusplus
 } // end extern "C"
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,8 +8,6 @@
 #include <llvm/Support/CommandLine.h>
 #include <llvm/Support/Debug.h>
 #include <llvm/Support/InitLLVM.h>
-#include <mlir/IR/AsmState.h>
-#include <mlir/IR/MLIRContext.h>
 
 #include "Interpreter.h"
 #include "Parse.h"
@@ -40,8 +38,6 @@ static cl::opt<enum Action>
 int main(int argc, char *argv[]) {
   llvm::InitLLVM X(argc, argv);
 
-  mlir::registerAsmPrinterCLOptions();
-  mlir::registerMLIRContextCLOptions();
   cl::ParseCommandLineOptions(argc, argv, "norac\n");
 
   if (Verbose) {


### PR DESCRIPTION
Nora had been dormant since mid-2023 and was pinned to LLVM/Clang/MLIR 15. This brings it up to the current toolchain and modern dev practices.

## Highlights
- **MLIR is now opt-in.** The `nir` dialect was dead scaffolding (`nora_init()` is never called), so it's gated behind `-DNORA_ENABLE_MLIR=ON` (default OFF). The default build needs only **LLVM 22 + GMP** — no MLIR install.
- **Builds on LLVM 22 / C++23.** The only real API break was `StringRef::startswith` → `starts_with`; also removed stray unused MLIR/ICU includes.
- **CMake modernized**: floor 3.10.2 → 3.24, dropped obsolete policy shims, uniform warnings-as-errors, and a new **`CMakePresets.json`** (debug/release/asan/ubsan/coverage/mlir).
- **CI/CD**: Ubuntu 24.04, LLVM 22 via apt.llvm.org, preset-based builds, GCC 14 / Clang 22, SHA-pinned actions (checkout v4 / codeql v3 / codecov v5), least-privilege `permissions:`, `concurrency:` cancellation, and a format check that **actually fails** on drift.
- **Dependabot**: fixed the broken `package-ecosystem: ""` stub → working `github-actions` config.
- **Dev tooling**: `.editorconfig`, `.pre-commit-config.yaml` (clang-format 22 + hygiene), pinned `.clang-format` standard.
- **Docs**: refreshed README build instructions and added a project `CLAUDE.md`.

## Verification (local, LLVM 22 / GCC 16 / Clang 22)
- GCC debug/release, Clang debug (`-Werror`), and UBSan: **13/13 tests pass**, warning-free.
- `cmake --preset mlir` without MLIR fails cleanly with "Could not find MLIR" (option path is well-formed).

The GitHub Actions runs themselves (apt.llvm.org install, codecov/codeql/scan-build execution) could not be exercised locally; the `scan-build` differential in particular may need a first-run tweak.