### PR TITLE
Add Claude Code edit-time clang-format hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_response.filePath // .tool_input.file_path' | { read -r f; echo \"$f\" | grep -qiE '\\.(c|cc|cxx|cpp|h|hh|hpp|hxx)$' && clang-format -i \"$f\"; } 2>/dev/null || true",
+            "command": "jq -r '.tool_response.filePath // .tool_input.file_path' | { read -r f; echo \"$f\" | grep -qiE '\\.(c|cc|cxx|cpp|h|hh|hpp|hxx)$' && command -v clang-format-22 >/dev/null 2>&1 && clang-format-22 -i \"$f\"; } 2>/dev/null || true",
             "statusMessage": "clang-format"
           }
         ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_response.filePath // .tool_input.file_path' | { read -r f; echo \"$f\" | grep -qiE '\\.(c|cc|cxx|cpp|h|hh|hpp|hxx)$' && clang-format -i \"$f\"; } 2>/dev/null || true",
+            "statusMessage": "clang-format"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,9 @@ ctest --preset debug         # unit (Catch2) + integration (lit/FileCheck) tests
   drift, so run it before committing.
 - Linting: `clang-tidy` (`.clang-tidy`).
 - Optional local hooks: `pre-commit install` (see `.pre-commit-config.yaml`).
+- Claude Code auto-formats edited C/C++ files via a `PostToolUse` hook in
+  `.claude/settings.json` (runs `clang-format-22`, matching the pinned
+  pre-commit version; silently no-ops if that binary is absent).
 
 ## Adding an integration test
 


### PR DESCRIPTION
## Summary

Adds a Claude Code `PostToolUse` hook so edited C/C++ files are auto-formatted, and documents it in `CLAUDE.md`.

- **`.claude/settings.json`** — a `PostToolUse` hook (matcher `Write|Edit`) that runs `clang-format-22 -i` on edited C/C++ files. It pins to `clang-format-22` (matching the `v22.1.5` pin in `.pre-commit-config.yaml`) and silently no-ops with exit 0 if that binary is absent, so it never rewrites files with an off-version formatter. This complements the commit-time pre-commit hook by formatting at edit time.
- **`CLAUDE.md`** — one bullet under **Conventions** documenting the hook.

## Notes

- Rebased onto latest `main`; the PR's earlier competing/outdated `CLAUDE.md` was dropped in favor of main's current one.
- `.claude/settings.local.json` (personal notify hooks) is gitignored and intentionally excluded.

Generated via `/init`.