### PR TITLE
Pin scan-build analyze job to ubuntu-22.04

### DIFF
--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -14,7 +14,10 @@ on:
 
 jobs:
   analyze:
-    runs-on: ubuntu-latest
+    # Pinned to 22.04 so the clang-15 analyzer compiles against libstdc++-12.
+    # On ubuntu-latest (24.04) the default libstdc++-14 <format> header cannot
+    # be parsed by clang-15, breaking the build before analysis runs (#68).
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- The `analyze` job in `.github/workflows/scan-build.yml` ran on `ubuntu-latest` (now Ubuntu 24.04, default `libstdc++-14`) while compiling with **clang-15**. clang-15 cannot parse libstdc++-14's internal `<format>` header, so the build failed before `scan-build` ever reached the analysis stage — even though no source file in this repo uses `std::format`.
- Pin the job to `ubuntu-22.04` (default `libstdc++-12`), which clang-15 compiles cleanly. This mirrors the already-passing clang matrix job in `test.yml`, which uses the same `clang-15` / `llvm-15` / `mlir-15` toolchain on `ubuntu-22.04`.

This is the minimal, environment-only fix. The broader toolchain modernization in #67 (LLVM 22 / C++23) remains the long-term path; this unblocks the `analyze` job in the meantime.

Fixes #68

## Test plan

- [x] `scan-build.yml` is valid YAML; `analyze` now runs on `ubuntu-22.04`
- [x] Matches the known-good clang-15 + libstdc++-12 combination proven by the passing `test.yml` clang job
- [ ] CI `analyze` (Scan-Build) job compiles and completes on this PR