### PR TITLE
Fix character print/read round-trip for glyphs and control names

### DIFF
--- a/src/Lex.cpp
+++ b/src/Lex.cpp
@@ -251,9 +251,12 @@ std::optional<Tok> Lex::maybeLexByteString(SourceStream &S) {
 }
 
 bool isCharacterName(SourceStream &S, std::string &Found) {
-  static const std::array Names = {"space",     "newline", "alarm",
-                                   "backspace", "delete",  "escape",
-                                   "null",      "return",  "tab"};
+  // Accepts both the reader's traditional names and the print names emitted by
+  // charReprFromCodePoint (nul/vtab/page/rubout) so printed control characters
+  // round-trip. "null" must precede "nul" so #\null is not truncated to #\nul.
+  static const std::array Names = {
+      "space",  "newline", "alarm", "backspace", "delete", "escape", "null",
+      "return", "tab",     "nul",   "vtab",      "page",   "rubout"};
 
   for (const auto *Name : Names) {
     if (S.isPrefix(Name)) {
@@ -317,9 +320,11 @@ std::optional<Tok> Lex::maybeLexSchemeChar(SourceStream &S) {
       (UTF8::isUTF8ReplacementCharacter(StartPtr, EndPtr) ||
        UTF8::isGraphUTF8(StartPtr, EndPtr)) &&
 
-      // followup character
-      (isDelimiter(S, 1) || S.peekChar(1) == EOF ||
-       std::isspace(S.peekChar(1)))) {
+      // followup character: the byte right after the glyph, at offset Bytes.
+      // Using offset 1 would land inside a multi-byte glyph (e.g. #\λ), so its
+      // printed form failed to lex back as a character.
+      (isDelimiter(S, Bytes) || S.peekChar(Bytes) == EOF ||
+       std::isspace(static_cast<unsigned char>(S.peekChar(Bytes))))) {
     auto Subview = S.getSubviewAndSkip(Bytes);
     // End is the index of the last consumed char, so that Tok::size() equals
     // the number of bytes consumed (#\ plus the character). Using getPosition()

--- a/test/integration/char-glyph-list-read.rkt
+++ b/test/integration/char-glyph-list-read.rkt
@@ -1,0 +1,5 @@
+;; RUN: norac %s | FileCheck %s
+;; A multi-byte glyph char followed by whitespace (inside a list) must lex too;
+;; the closing-delimiter case is covered by char-glyph-read.rkt.
+;; CHECK: '(#\λ #\a)
+(linklet () () '(#\λ #\a))

--- a/test/integration/char-glyph-read.rkt
+++ b/test/integration/char-glyph-read.rkt
@@ -1,0 +1,4 @@
+;; RUN: norac %s | FileCheck %s
+;; Reading a printed multi-byte glyph char literal back must yield the same char.
+;; CHECK: #\λ
+(linklet () () '#\λ)

--- a/test/integration/char-nul-read.rkt
+++ b/test/integration/char-nul-read.rkt
@@ -1,0 +1,3 @@
+;; RUN: norac %s | FileCheck %s
+;; CHECK: #\nul
+(linklet () () '#\nul)

--- a/test/integration/char-null-read.rkt
+++ b/test/integration/char-null-read.rkt
@@ -1,0 +1,4 @@
+;; RUN: norac %s | FileCheck %s
+;; The traditional #\null name must still lex (not be truncated to #\nul).
+;; CHECK: #\null
+(linklet () () '#\null)

--- a/test/integration/char-page-read.rkt
+++ b/test/integration/char-page-read.rkt
@@ -1,0 +1,3 @@
+;; RUN: norac %s | FileCheck %s
+;; CHECK: #\page
+(linklet () () '#\page)

--- a/test/integration/char-rubout-read.rkt
+++ b/test/integration/char-rubout-read.rkt
@@ -1,0 +1,3 @@
+;; RUN: norac %s | FileCheck %s
+;; CHECK: #\rubout
+(linklet () () '#\rubout)

--- a/test/integration/char-vtab-read.rkt
+++ b/test/integration/char-vtab-read.rkt
@@ -1,0 +1,3 @@
+;; RUN: norac %s | FileCheck %s
+;; CHECK: #\vtab
+(linklet () () '#\vtab)


### PR DESCRIPTION
## Summary

Fixes the two character print → re-read round-trip gaps tracked in #73, where a printed character did not read back as the same character.

- **Multi-byte glyph literals (Bug 1).** `maybeLexSchemeChar` checked the followup delimiter at byte offset `1`, which lands *inside* a multi-byte UTF-8 glyph. Printed forms like `#\λ` therefore failed to lex back as a character — and, worse, drove `parseQuote`/`parseValue` into unbounded recursion (stack overflow) rather than the symbol fallback the issue predicted. The followup offset now advances by the glyph's UTF-8 byte length.
- **Control-char print names (Bug 2).** `charReprFromCodePoint` emits Racket's *print* names (`nul`, `vtab`, `page`, `rubout`), but the reader's `isCharacterName` table only knew `null`/`delete` and lacked `vtab`/`page`, so `#\nul`/`#\vtab`/`#\page`/`#\rubout` read back as symbols. The table now accepts these print names, with `null` ordered before `nul` so `#\null` is not truncated.

## Test plan

- [x] `ctest --preset debug` — 13/13 passing (includes the `lit` integration suite)
- [x] `nora-lit test/integration -v` — 54/54 passing, including 6 new round-trip tests
- [x] `clang-format --dry-run --Werror src/Lex.cpp` — clean
- [x] Manual repro confirms `#\λ`, `#\nul`, `#\vtab`, `#\page`, `#\rubout` now round-trip; `#\null` still lexes
- [x] New regression tests added (`test/integration/char-*-read.rkt`)

Fixes #73