### PR TITLE
Accept keyword datums in quotes

### DIFF
--- a/src/AST.cpp
+++ b/src/AST.cpp
@@ -83,6 +83,16 @@ void Symbol::dump() const { llvm::dbgs() << "#<symbol:" << Name << ">"; }
 void Symbol::write() const { std::cout << getName().str(); }
 
 //
+// Implementation of Keyword node.
+//
+void Keyword::dump() const { llvm::dbgs() << "#<keyword:" << Name << ">"; }
+
+// Keywords print in Racket read syntax (#:foo); Name holds the bare keyword, so
+// the #: prefix is restored here. The leading quote (if any) is emitted by the
+// enclosing QuotedExpr, since keywords are not self-quoting.
+void Keyword::write() const { std::cout << "#:" << getName().str(); }
+
+//
 // Implementation of Char node.
 //
 void Char::dump() const { llvm::dbgs() << "#\\" << Value; }

--- a/src/AnalysisFreeVars.cpp
+++ b/src/AnalysisFreeVars.cpp
@@ -162,3 +162,8 @@ void AnalysisFreeVars::visit(ast::Symbol const &Sym) {
   // Symbols have no free variables.
   // Nothing to do.
 }
+
+void AnalysisFreeVars::visit(ast::Keyword const &K) {
+  // Keywords have no free variables.
+  // Nothing to do.
+}

--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -490,3 +490,8 @@ void Interpreter::visit(ast::Symbol const &Sym) {
   LLVM_DEBUG(llvm::dbgs() << "Interpreting Symbol\n");
   Result = std::unique_ptr<ast::ValueNode>(Sym.clone());
 }
+
+void Interpreter::visit(ast::Keyword const &K) {
+  LLVM_DEBUG(llvm::dbgs() << "Interpreting Keyword\n");
+  Result = std::unique_ptr<ast::ValueNode>(K.clone());
+}

--- a/src/Parse.cpp
+++ b/src/Parse.cpp
@@ -262,6 +262,9 @@ std::unique_ptr<ast::ValueNode> Parse::parseValue(SourceStream &S) {
   if (auto Sym = parseSymbol(S)) {
     return Sym;
   }
+  if (auto Kw = parseKeyword(S)) {
+    return Kw;
+  }
   if (auto L = parseLiteralList(S)) {
     return L;
   }
@@ -409,6 +412,17 @@ std::unique_ptr<ast::Symbol> Parse::parseSymbol(SourceStream &S) {
     return nullptr;
   }
   return std::make_unique<ast::Symbol>(T.Value);
+}
+
+// Parse a keyword datum (#:foo). The lexer emits a KEYWORD token whose value is
+// the bare keyword (without the leading #:).
+std::unique_ptr<ast::Keyword> Parse::parseKeyword(SourceStream &S) {
+  Tok T = gettok(S);
+  if (!T.is(Tok::TokType::KEYWORD)) {
+    S.rewind(T.size());
+    return nullptr;
+  }
+  return std::make_unique<ast::Keyword>(T.Value);
 }
 
 // Parses an expression of the form:

--- a/src/include/AST.h
+++ b/src/include/AST.h
@@ -46,6 +46,7 @@ public:
     AST_Char,
     AST_Closure, // result of evaluating a Lambda expression
     AST_Integer,
+    AST_Keyword,
     AST_Lambda,
     AST_List,
     AST_String,
@@ -193,6 +194,34 @@ public:
 
   static bool classof(const ASTNode *N) {
     return N->getKind() == ASTNodeKind::AST_Symbol;
+  }
+
+private:
+  llvm::SmallString<32> Name;
+};
+
+// A keyword datum, e.g. #:foo. Name holds the bare keyword (without the leading
+// #:), matching the lexer's KEYWORD token. Like symbols, keywords are not
+// self-quoting, so the enclosing QuotedExpr emits a leading quote ('#:foo).
+class Keyword : public ClonableNode<Keyword, ValueNode> {
+public:
+  explicit Keyword(llvm::StringRef Name)
+      : ClonableNode(ASTNodeKind::AST_Keyword), Name(Name) {}
+  Keyword(const Keyword &K)
+      : ClonableNode(ASTNodeKind::AST_Keyword), Name(K.Name) {}
+  Keyword(Keyword &&) = default;
+  Keyword &operator=(const Keyword &K) = delete;
+  Keyword &operator=(Keyword &&K) = delete;
+  virtual ~Keyword() = default;
+
+  bool operator==(const Keyword &K) const { return getName() == K.getName(); }
+
+  [[nodiscard]] llvm::StringRef getName() const { return Name; }
+  LLVM_DUMP_METHOD void dump() const override;
+  void write() const override;
+
+  static bool classof(const ASTNode *N) {
+    return N->getKind() == ASTNodeKind::AST_Keyword;
   }
 
 private:

--- a/src/include/ASTVisitor.h
+++ b/src/include/ASTVisitor.h
@@ -17,6 +17,7 @@ public:
   virtual void visit(ast::Identifier const &Id) = 0;
   virtual void visit(ast::IfCond const &If) = 0;
   virtual void visit(ast::Integer const &Int) = 0;
+  virtual void visit(ast::Keyword const &K) = 0;
   virtual void visit(ast::Lambda const &L) = 0;
   virtual void visit(ast::LetValues const &LV) = 0;
   virtual void visit(ast::Linklet const &Linklet) = 0;

--- a/src/include/AST_fwd.h
+++ b/src/include/AST_fwd.h
@@ -11,6 +11,7 @@ class DefineValues;
 class Identifier;
 class IfCond;
 class Integer;
+class Keyword;
 class Lambda;
 class LetValues;
 class Linklet;

--- a/src/include/AnalysisFreeVars.h
+++ b/src/include/AnalysisFreeVars.h
@@ -25,6 +25,7 @@ public:
   virtual void visit(ast::Identifier const &Id) override;
   virtual void visit(ast::IfCond const &If) override;
   virtual void visit(ast::Integer const &Int) override;
+  virtual void visit(ast::Keyword const &K) override;
   virtual void visit(ast::Lambda const &L) override;
   virtual void visit(ast::LetValues const &LV) override;
   virtual void visit(ast::Linklet const &Linklet) override;

--- a/src/include/Interpreter.h
+++ b/src/include/Interpreter.h
@@ -29,6 +29,7 @@ public:
   virtual void visit(ast::Identifier const &Id) override;
   virtual void visit(ast::IfCond const &If) override;
   virtual void visit(ast::Integer const &Int) override;
+  virtual void visit(ast::Keyword const &K) override;
   virtual void visit(ast::Lambda const &L) override;
   virtual void visit(ast::LetValues const &LV) override;
   virtual void visit(ast::Linklet const &Linklet) override;

--- a/src/include/Parse.h
+++ b/src/include/Parse.h
@@ -39,6 +39,7 @@ std::unique_ptr<ast::Formal> parseFormals(SourceStream &S);
 std::unique_ptr<ast::Identifier> parseIdentifier(SourceStream &S);
 std::unique_ptr<ast::IfCond> parseIfCond(SourceStream &S);
 std::unique_ptr<ast::Integer> parseInteger(SourceStream &S);
+std::unique_ptr<ast::Keyword> parseKeyword(SourceStream &S);
 std::unique_ptr<ast::Lambda> parseLambda(SourceStream &S);
 std::unique_ptr<ast::LetValues> parseLetValues(SourceStream &S);
 std::unique_ptr<ast::Linklet> parseLinklet(SourceStream &S);

--- a/test/integration/quote19.rkt
+++ b/test/integration/quote19.rkt
@@ -1,0 +1,3 @@
+;; RUN: norac %s | FileCheck %s
+;; CHECK: '#:foo
+(linklet () () '#:foo)

--- a/test/integration/quote20.rkt
+++ b/test/integration/quote20.rkt
@@ -1,0 +1,3 @@
+;; RUN: norac %s | FileCheck %s
+;; CHECK: '(#:foo 1)
+(linklet () () '(#:foo 1))

--- a/test/unit/test_parse.cpp
+++ b/test/unit/test_parse.cpp
@@ -180,6 +180,20 @@ TEST_CASE("Lexing Symbol tokens", "[parser]") {
   REQUIRE(Tok.Value == R"(\)");
 }
 
+TEST_CASE("Lexing Keyword tokens", "[parser]") {
+  SourceStream Kw("#:foo");
+  Tok Tok = gettok(Kw);
+  REQUIRE(Tok.is(Tok::TokType::KEYWORD));
+  REQUIRE(Tok.Value == "foo");
+
+  SourceStream QuotedKw("'#:bar");
+  Tok = gettok(QuotedKw);
+  REQUIRE(Tok.is(Tok::TokType::SYMBOLMARK));
+  Tok = gettok(QuotedKw);
+  REQUIRE(Tok.is(Tok::TokType::KEYWORD));
+  REQUIRE(Tok.Value == "bar");
+}
+
 TEST_CASE("Lexing identifiers starting with numbers", "[parser]") {
   SourceStream Sym("1/bound-identifier=?");
   Tok Tok = gettok(Sym);


### PR DESCRIPTION
## Summary

- Add a `Keyword` `ValueNode` (analogous to `Symbol`) so quoted keyword literals like `'#:foo` parse and evaluate. The lexer already emitted `Tok::KEYWORD` for `#:foo`, but `parseValue` had no branch for it, so `(linklet () () '#:foo)` failed to parse.
- `parseKeyword` consumes the `KEYWORD` token; the node stores the bare keyword and prints in Racket's read form (`#:foo`). Keywords are not self-quoting, so the enclosing `QuotedExpr` adds the leading quote — `'#:foo` prints as `'#:foo`, and `'(#:foo 1)` as `'(#:foo 1)`.
- Wire the new node through the `ASTVisitor` interface (`Interpreter`, `AnalysisFreeVars`).

Closes #72

## Test plan

- [x] `ctest --preset debug` — 14/14 unit tests pass, incl. new "Lexing Keyword tokens"
- [x] `nora-lit test/integration` — 50/50 pass, incl. new `quote19.rkt` (`'#:foo`) and `quote20.rkt` (`'(#:foo 1)`)
- [x] `cmake --build --preset debug` — warning-clean (warnings-as-errors)
- [x] `clang-format` — clean on all edited files