### PR TITLE
Interpret #%variable-reference core form

### DIFF
--- a/src/AST.cpp
+++ b/src/AST.cpp
@@ -430,6 +430,22 @@ void Values::write() const {
 }
 
 //
+// Implementation of VariableReference node.
+//
+void VariableReference::dump() const {
+  llvm::dbgs() << "(#%variable-reference";
+  if (hasId()) {
+    llvm::dbgs() << " ";
+    getId().dump();
+  }
+  llvm::dbgs() << ")";
+}
+
+// A variable reference is opaque: it always prints as #<variable-reference>,
+// independent of the referenced binding.
+void VariableReference::write() const { std::cout << "#<variable-reference>"; }
+
+//
 // Implementation of LetValues node.
 //
 

--- a/src/AnalysisFreeVars.cpp
+++ b/src/AnalysisFreeVars.cpp
@@ -108,6 +108,11 @@ void AnalysisFreeVars::visit(ast::Vector const &Vec) {
   }
 }
 
+void AnalysisFreeVars::visit(ast::VariableReference const &VR) {
+  // A variable reference is an opaque value with no free variables.
+  // Nothing to do.
+}
+
 void AnalysisFreeVars::visit(ast::Application const &A) {
   // Iterate through all the Application expressions and check for free
   // variables.

--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -284,6 +284,12 @@ void Interpreter::applyFormals(
   Envs.pop_back();
 }
 
+// A variable reference is an opaque, self-evaluating value.
+void Interpreter::visit(ast::VariableReference const &VR) {
+  LLVM_DEBUG(llvm::dbgs() << "Interpreting VariableReference\n");
+  Result = std::unique_ptr<ast::ValueNode>(VR.clone());
+}
+
 void Interpreter::visit(ast::Application const &A) {
   // 1. Evaluate the first expression.
   // which should evaluate to a lambda expression.

--- a/src/Parse.cpp
+++ b/src/Parse.cpp
@@ -68,9 +68,9 @@ using namespace Lex;
 //       | (quote <datum>)                                  - parseQuote
 //       | (with-continuation-mark <expr> <expr> <expr>)
 //       | (<expr> ...+)                                    - parseApplication
-//       | (%variable-reference <id>)
-//       | (%variable-reference (%top . id))  <- Allowed?
-//       | (%variable-reference)              <- Allowed?
+//       | (#%variable-reference)                 - parseVariableReference
+//       | (#%variable-reference <id>)            - parseVariableReference
+//       | (#%variable-reference (#%top . id))    - parseVariableReference
 //
 // formals := <id>                                          - parseFormals
 //          | (<id> ...+ . id)
@@ -231,6 +231,11 @@ std::unique_ptr<ast::ExprNode> Parse::parseExpr(SourceStream &S) {
   std::unique_ptr<ast::QuotedExpr> Q = parseQuote(S);
   if (Q) {
     return Q;
+  }
+
+  std::unique_ptr<ast::VariableReference> VR = parseVariableReference(S);
+  if (VR) {
+    return VR;
   }
 
   std::unique_ptr<ast::Application> A = parseApplication(S);
@@ -882,6 +887,81 @@ std::unique_ptr<ast::SetBang> Parse::parseSetBang(SourceStream &S) {
   }
 
   return Set;
+}
+
+// Parse a variable reference, in any of its three fully-expanded forms:
+//   (#%variable-reference)
+//   (#%variable-reference id)
+//   (#%variable-reference (#%top . id))
+std::unique_ptr<ast::VariableReference>
+Parse::parseVariableReference(SourceStream &S) {
+  size_t Start = S.getPosition();
+
+  Tok T = gettok(S);
+  if (!T.is(Tok::TokType::LPAREN)) {
+    S.rewindTo(Start);
+    return nullptr;
+  }
+
+  T = gettok(S);
+  if (!T.is(Tok::TokType::K_VARIABLE_REFERENCE)) {
+    S.rewindTo(Start);
+    return nullptr;
+  }
+
+  auto VarRef = std::make_unique<ast::VariableReference>();
+
+  // The bare (#%variable-reference) form has no operand.
+  size_t BeforeOperand = S.getPosition();
+  T = gettok(S);
+  if (T.is(Tok::TokType::RPAREN)) {
+    return VarRef;
+  }
+
+  if (T.is(Tok::TokType::LPAREN)) {
+    // (#%variable-reference (#%top . id))
+    Tok Top = gettok(S);
+    if (!Top.is(Tok::TokType::ID) || Top.Value != "#%top") {
+      S.rewindTo(Start);
+      return nullptr;
+    }
+
+    T = gettok(S);
+    if (!T.is(Tok::TokType::DOT)) {
+      S.rewindTo(Start);
+      return nullptr;
+    }
+
+    std::unique_ptr<ast::Identifier> Id = parseIdentifier(S);
+    if (!Id) {
+      S.rewindTo(Start);
+      return nullptr;
+    }
+    VarRef->setId(*Id);
+
+    T = gettok(S);
+    if (!T.is(Tok::TokType::RPAREN)) {
+      S.rewindTo(Start);
+      return nullptr;
+    }
+  } else {
+    // (#%variable-reference id)
+    S.rewindTo(BeforeOperand);
+    std::unique_ptr<ast::Identifier> Id = parseIdentifier(S);
+    if (!Id) {
+      S.rewindTo(Start);
+      return nullptr;
+    }
+    VarRef->setId(*Id);
+  }
+
+  T = gettok(S);
+  if (!T.is(Tok::TokType::RPAREN)) {
+    S.rewindTo(Start);
+    return nullptr;
+  }
+
+  return VarRef;
 }
 
 std::unique_ptr<ast::IfCond> Parse::parseIfCond(SourceStream &S) {

--- a/src/include/AST.h
+++ b/src/include/AST.h
@@ -12,6 +12,7 @@
 #include <gmp.h>
 #include <iostream>
 #include <memory>
+#include <optional>
 #include <ranges>
 #include <utility>
 
@@ -54,6 +55,7 @@ public:
     AST_String,
     AST_Symbol,
     AST_Values,
+    AST_VariableReference,
     AST_Vector,
     AST_Void,
     AST_RuntimeFunction,
@@ -799,6 +801,34 @@ public:
 
 private:
   llvm::SmallVector<std::unique_ptr<ExprNode>> Exprs;
+};
+
+// The result of a (#%variable-reference ...) form. A variable reference is an
+// opaque runtime value; it prints as #<variable-reference> regardless of the
+// referenced binding. The optional Id records the referenced identifier for the
+// (#%variable-reference id) / (#%variable-reference (#%top . id)) forms; the
+// bare (#%variable-reference) form leaves it empty.
+// https://docs.racket-lang.org/reference/__top.html
+class VariableReference : public ClonableNode<VariableReference, ValueNode> {
+public:
+  VariableReference() : ClonableNode(ASTNodeKind::AST_VariableReference) {}
+  VariableReference(const VariableReference &V) = default;
+  VariableReference(VariableReference &&V) = default;
+  ~VariableReference() = default;
+
+  void setId(const Identifier &I) { Id = I; }
+  [[nodiscard]] bool hasId() const { return Id.has_value(); }
+  [[nodiscard]] const Identifier &getId() const { return *Id; }
+
+  LLVM_DUMP_METHOD void dump() const override;
+  void write() const override;
+
+  static bool classof(const ASTNode *N) {
+    return N->getKind() == ASTNodeKind::AST_VariableReference;
+  }
+
+private:
+  std::optional<Identifier> Id;
 };
 
 // A vector datum, e.g. #(1 2). Unlike lists, vectors are NOT self-quoting, so

--- a/src/include/ASTVisitor.h
+++ b/src/include/ASTVisitor.h
@@ -30,6 +30,7 @@ public:
   virtual void visit(ast::String const &Str) = 0;
   virtual void visit(ast::Symbol const &Sym) = 0;
   virtual void visit(ast::Values const &V) = 0;
+  virtual void visit(ast::VariableReference const &VR) = 0;
   virtual void visit(ast::Vector const &Vec) = 0;
   virtual void visit(ast::Void const &Vd) = 0;
 };

--- a/src/include/AST_fwd.h
+++ b/src/include/AST_fwd.h
@@ -24,6 +24,7 @@ class SetBang;
 class String;
 class Symbol;
 class Values;
+class VariableReference;
 class Vector;
 class Void;
 }; // namespace ast

--- a/src/include/AnalysisFreeVars.h
+++ b/src/include/AnalysisFreeVars.h
@@ -38,6 +38,7 @@ public:
   virtual void visit(ast::String const &Str) override;
   virtual void visit(ast::Symbol const &Sym) override;
   virtual void visit(ast::Values const &V) override;
+  virtual void visit(ast::VariableReference const &VR) override;
   virtual void visit(ast::Vector const &Vec) override;
   virtual void visit(ast::Void const &Vd) override;
 

--- a/src/include/Interpreter.h
+++ b/src/include/Interpreter.h
@@ -42,6 +42,7 @@ public:
   virtual void visit(ast::String const &Str) override;
   virtual void visit(ast::Symbol const &Sym) override;
   virtual void visit(ast::Values const &V) override;
+  virtual void visit(ast::VariableReference const &VR) override;
   virtual void visit(ast::Vector const &Vec) override;
   virtual void visit(ast::Void const &Vd) override;
 

--- a/src/include/Parse.h
+++ b/src/include/Parse.h
@@ -53,6 +53,7 @@ std::unique_ptr<ast::TLNode> parseDefn(SourceStream &S);
 std::unique_ptr<ast::TLNode> parseDefnOrExpr(SourceStream &S);
 std::unique_ptr<ast::ValueNode> parseValue(SourceStream &S);
 std::unique_ptr<ast::Values> parseValues(SourceStream &S);
+std::unique_ptr<ast::VariableReference> parseVariableReference(SourceStream &S);
 std::unique_ptr<ast::Vector> parseVector(SourceStream &S);
 
 }; // namespace Parse

--- a/test/integration/variable-reference.rkt
+++ b/test/integration/variable-reference.rkt
@@ -1,0 +1,3 @@
+;; RUN: norac %s | FileCheck %s
+;; CHECK: #<variable-reference>
+(linklet () () (#%variable-reference))

--- a/test/integration/variable-reference1.rkt
+++ b/test/integration/variable-reference1.rkt
@@ -1,0 +1,5 @@
+;; RUN: norac %s | FileCheck %s
+;; CHECK: #<variable-reference>
+(linklet () ()
+  (define-values (x) (values 1))
+  (#%variable-reference x))

--- a/test/integration/variable-reference2.rkt
+++ b/test/integration/variable-reference2.rkt
@@ -1,0 +1,5 @@
+;; RUN: norac %s | FileCheck %s
+;; CHECK: #<variable-reference>
+(linklet () ()
+  (define-values (x) (values 1))
+  (#%variable-reference (#%top . x)))

--- a/test/unit/test_parse.cpp
+++ b/test/unit/test_parse.cpp
@@ -337,3 +337,27 @@ TEST_CASE("Parsing begin", "[parser]") {
   REQUIRE(B);
   REQUIRE(B->bodyCount() == 3);
 }
+
+TEST_CASE("Parsing variable references", "[parser]") {
+  SourceStream V1("(#%variable-reference)");
+  std::unique_ptr<ast::VariableReference> V = parseVariableReference(V1);
+  REQUIRE(V);
+  REQUIRE_FALSE(V->hasId());
+
+  SourceStream V2("(#%variable-reference x)");
+  V = parseVariableReference(V2);
+  REQUIRE(V);
+  REQUIRE(V->hasId());
+  REQUIRE(V->getId().getName() == "x");
+
+  SourceStream V3("(#%variable-reference (#%top . x))");
+  V = parseVariableReference(V3);
+  REQUIRE(V);
+  REQUIRE(V->hasId());
+  REQUIRE(V->getId().getName() == "x");
+
+  // A plain application must not be misparsed as a variable reference.
+  SourceStream V4("(f x)");
+  V = parseVariableReference(V4);
+  REQUIRE_FALSE(V);
+}


### PR DESCRIPTION
## Summary

- Add a `VariableReference` AST value node and parse the three fully-expanded
  forms of the core syntax: `(#%variable-reference)`,
  `(#%variable-reference id)`, and `(#%variable-reference (#%top . id))`.
- The interpreter evaluates it to itself — an opaque, self-evaluating value that
  prints as `#<variable-reference>`, matching Racket v9.2.
- Wire the new node through the `ASTVisitor` interface (`Interpreter`,
  `AnalysisFreeVars`) and the parser (`parseVariableReference`, tried in
  `parseExpr` before `parseApplication`).

This form appears throughout `expander/expander.rktl` (always as
`(variable-reference-from-unsafe? (#%variable-reference))`); previously the
parser had the `#%variable-reference` token but no production for it, so these
expressions failed to parse.

Fixes #13

## Test plan

- [x] `ctest --preset debug` — Catch2 + lit/FileCheck, 14/14 passing
- [x] New unit test `Parsing variable references` covers all three forms and the
      non-match (plain application) case
- [x] New integration tests `variable-reference{,1,2}.rkt` — each prints
      `#<variable-reference>`
- [x] Warning-clean build (warnings-as-errors) and `clang-format` clean