### PR TITLE
Interpret letrec-values

### DIFF
--- a/src/AST.cpp
+++ b/src/AST.cpp
@@ -400,7 +400,7 @@ void Values::write() const {
 //
 
 LetValues::LetValues(const LetValues &DV)
-    : ClonableNode(ASTNodeKind::AST_LetValues) {
+    : ClonableNode(ASTNodeKind::AST_LetValues), Rec(DV.Rec) {
   for (auto const &Id : DV.Ids) {
     Ids.emplace_back(Id);
   }
@@ -432,7 +432,7 @@ ExprNode const &LetValues::getBodyExpr(size_t Idx) const { return *Body[Idx]; }
 size_t LetValues::exprsCount() const { return Exprs.size(); }
 
 void LetValues::dump() const {
-  llvm::dbgs() << "(let-values (";
+  llvm::dbgs() << (Rec ? "(letrec-values (" : "(let-values (");
   for (size_t Idx = 0; Idx < bindingCount(); Idx++) {
     llvm::dbgs() << "[";
     for (const auto &Id : getBindingIds(Idx)) {

--- a/src/AnalysisFreeVars.cpp
+++ b/src/AnalysisFreeVars.cpp
@@ -140,7 +140,19 @@ void AnalysisFreeVars::visit(ast::LetValues const &LV) {
     for (auto const &Var : LV.getBindingIds(Idx))
       LVVars.insert(Var);
 
+  // In let-values the binding expressions are evaluated in the enclosing scope,
+  // so the bound identifiers do not shadow them. In letrec-values the
+  // identifiers are in scope for the binding expressions too, enabling
+  // recursion, so those references must not be reported as free.
+  if (!LV.isRec())
+    for (size_t Idx = 0; Idx < LV.bindingCount(); Idx++)
+      LV.getBindingExpr(Idx).accept(*this);
+
   Vars.push_back(LVVars);
+
+  if (LV.isRec())
+    for (size_t Idx = 0; Idx < LV.bindingCount(); Idx++)
+      LV.getBindingExpr(Idx).accept(*this);
 
   for (size_t Idx = 0; Idx < LV.bodyCount(); Idx++)
     LV.getBodyExpr(Idx).accept(*this);

--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -402,11 +402,65 @@ void Interpreter::visit(ast::String const &Str) {
   Result = std::unique_ptr<ast::ValueNode>(Str.clone());
 }
 
+// Bind one let-values / letrec-values clause into Env: a single identifier
+// takes the whole value, while several identifiers require a Values result
+// whose arity matches. Returns false (after reporting) on a mismatch.
+static bool bindClause(Environment &Env, const ast::LetValues::IdRange &Ids,
+                       std::unique_ptr<ast::ValueNode> Val) {
+  if (std::ranges::size(Ids) == 1) {
+    Env.add(Ids[0], std::move(Val));
+    return true;
+  }
+
+  auto Vs = dyn_castU<ast::Values>(Val);
+  if (!Vs) {
+    std::cerr << "Expected a values node, got ";
+    Val->dump();
+    return false;
+  }
+  if (std::ranges::size(Ids) != Vs->countExprs()) {
+    std::cerr << "Expected " << std::ranges::size(Ids) << " values, got "
+              << Vs->countExprs() << std::endl;
+    return false;
+  }
+
+  const auto &ValuesExprRange = Vs->getExprs();
+  for (size_t Idx = 0; Idx < Vs->countExprs(); ++Idx) {
+    // Elements of a Values node are values stored as exprs; downcast in place.
+    std::unique_ptr<ast::ExprNode> EPtr(ValuesExprRange[Idx].clone());
+    Env.add(Ids[Idx], dyn_castU<ast::ValueNode>(EPtr));
+  }
+  return true;
+}
+
 void Interpreter::visit(ast::LetValues const &L) {
   LLVM_DEBUG(llvm::dbgs() << "Interpreting LetValues\n");
   LLVM_DEBUG(L.dump(); llvm::dbgs() << "\n";);
 
-  // 1. Evaluate each of the expressions in order.
+  if (L.isRec()) {
+    // letrec-values: the bound identifiers are in scope while their own binding
+    // expressions are evaluated, so push a fresh environment first and fill it
+    // in as each clause is evaluated left to right. Keeping it live on the
+    // stack lets self- and mutually-recursive closures resolve the bindings the
+    // same way top-level recursive definitions do.
+    Envs.emplace_back();
+    for (size_t Idx = 0; Idx < L.exprsCount(); ++Idx) {
+      L.getBindingExpr(Idx).accept(*this);
+      assert(Result);
+      if (!bindClause(Envs.back(), L.getBindingIds(Idx), std::move(Result))) {
+        Result = nullptr;
+        Envs.pop_back();
+        return;
+      }
+    }
+    for (size_t I = 0; I < L.bodyCount(); ++I)
+      L.getBodyExpr(I).accept(*this);
+    Envs.pop_back();
+    return;
+  }
+
+  // let-values: every binding expression is evaluated in the enclosing
+  // environment before any of the identifiers are bound.
   std::vector<std::unique_ptr<ast::ValueNode>> ExprValues;
   ExprValues.reserve(L.exprsCount());
   for (size_t Idx = 0; Idx < L.exprsCount(); ++Idx) {
@@ -415,59 +469,20 @@ void Interpreter::visit(ast::LetValues const &L) {
     ExprValues.emplace_back(std::move(Result));
   }
 
-  // 2. Create an environment where each identifier is bound to the
-  // corresponding value. Then evaluate the body in this environment.
-  // If the binding variable list has a single identifier, it's simply assigned
-  // to the value of the expression. If on the other hand, it's a list of
-  // identifiers, then it should have the same length as the values list and
-  // each identifier is assigned to the corresponding value.
   LLVM_DEBUG(llvm::dbgs() << "Creating environment for LetValues\n");
   Environment Env;
   for (size_t Idx = 0; Idx < ExprValues.size(); ++Idx) {
-    if (std::ranges::size(L.getBindingIds(Idx)) == 1) {
-      Env.add(*L.getBindingIds(Idx).begin(), std::move(ExprValues[Idx]));
-    } else {
-      std::unique_ptr<ast::ValueNode> V = std::move(ExprValues[Idx]);
-
-      if (auto const &Vs = dyn_castU<ast::Values>(V)) {
-        if (std::ranges::size(L.getBindingIds(Idx)) != Vs->countExprs()) {
-          std::cerr << "Expected " << std::ranges::size(L.getBindingIds(Idx))
-                    << " values, got " << ExprValues.size() << std::endl;
-          return;
-        }
-
-        const auto &IdsExprRange = L.getBindingIds(Idx);
-        const auto &ValuesExprRange = Vs->getExprs();
-
-        for (size_t Idx = 0; Idx < Vs->countExprs(); ++Idx) {
-          // All the elements in ValuesExprRange are Value,
-          // not Expr but we need to downcast them to add
-          // them to the environment.
-          const auto &E = ValuesExprRange[Idx];
-          std::unique_ptr<ast::ExprNode> EPtr(E.clone());
-          std::unique_ptr<ast::ValueNode> Val = dyn_castU<ast::ValueNode>(EPtr);
-
-          LLVM_DEBUG(llvm::dbgs()
-                     << "Adding " << std::string(IdsExprRange[Idx].getName())
-                     << " to environment\n");
-          Env.add(IdsExprRange[Idx], std::move(Val));
-        }
-
-      } else {
-        std::cerr << "Expected a values node, got ";
-        V->dump();
-        return;
-      }
+    if (!bindClause(Env, L.getBindingIds(Idx), std::move(ExprValues[Idx]))) {
+      Result = nullptr;
+      return;
     }
   }
   LLVM_DEBUG(llvm::dbgs() << " Pushing new environment for LetValues\n");
   Envs.push_back(Env);
 
   LLVM_DEBUG(llvm::dbgs() << "Evaluating body of LetValues\n");
-  for (size_t I = 0; I < L.exprsCount(); ++I) {
-    // 3. Return the result of the let-values expression.
+  for (size_t I = 0; I < L.bodyCount(); ++I)
     L.getBodyExpr(I).accept(*this);
-  }
 
   Envs.pop_back();
 }

--- a/src/Parse.cpp
+++ b/src/Parse.cpp
@@ -63,7 +63,7 @@ using namespace Lex;
 //       | (begin <expr> ...+)                              - parseBegin
 //       | (begin0 <expr> ...+)                             - parseBegin
 //       | (let-values ([<id> ...) <expr>] ...) <expr>)     - parseLetValues
-//       | (letrec-values ([(<id> ...) <expr>] ...) <expr>)
+//       | (letrec-values ([(<id> ...) <expr>] ...) <expr>) - parseLetValues
 //       | (set! <id> <expr>)                               - parseSetBang
 //       | (quote <datum>)                                  - parseQuote
 //       | (with-continuation-mark <expr> <expr> <expr>)
@@ -870,8 +870,10 @@ Parse::parseBooleanLiteral(SourceStream &S) {
   return nullptr;
 }
 
-// Parse a let-values form.
-// (let-values ([(id ...) val-expr] ...) body ...+)
+// Parse a let-values or letrec-values form. The two share an identical
+// grammar; they differ only in scoping, tracked by the LetValues Rec flag.
+// (let-values    ([(id ...) val-expr] ...) body ...+)
+// (letrec-values ([(id ...) val-expr] ...) body ...+)
 std::unique_ptr<ast::LetValues> Parse::parseLetValues(SourceStream &S) {
   size_t Start = S.getPosition();
 
@@ -882,12 +884,13 @@ std::unique_ptr<ast::LetValues> Parse::parseLetValues(SourceStream &S) {
   }
 
   T = gettok(S);
-  if (!T.is(Tok::TokType::LET_VALUES)) {
+  if (!T.is(Tok::TokType::LET_VALUES) && !T.is(Tok::TokType::LETREC_VALUES)) {
     S.rewindTo(Start);
     return nullptr;
   }
 
   auto Let = std::make_unique<ast::LetValues>();
+  Let->setRec(T.is(Tok::TokType::LETREC_VALUES));
 
   T = gettok(S);
   if (!T.is(Tok::TokType::LPAREN)) {

--- a/src/include/AST.h
+++ b/src/include/AST.h
@@ -637,6 +637,12 @@ public:
   size_t exprsCount() const;
   size_t bodyCount() const { return Body.size(); }
 
+  // A letrec-values form binds its identifiers over the binding expressions as
+  // well as the body, enabling recursive and mutually-recursive definitions; a
+  // plain let-values evaluates its binding expressions in the outer scope.
+  bool isRec() const { return Rec; }
+  void setRec(bool R) { Rec = R; }
+
   LLVM_DUMP_METHOD void dump() const override;
 
   static bool classof(const ASTNode *N) {
@@ -647,6 +653,7 @@ private:
   llvm::SmallVector<llvm::SmallVector<Identifier>> Ids;
   llvm::SmallVector<std::unique_ptr<ExprNode>> Exprs;
   llvm::SmallVector<std::unique_ptr<ExprNode>> Body;
+  bool Rec = false;
 };
 
 class List : public ClonableNode<List, ValueNode> {

--- a/test/integration/let-values4.rkt
+++ b/test/integration/let-values4.rkt
@@ -1,0 +1,10 @@
+;; RUN: norac %s | FileCheck %s
+;; CHECK: 15
+;; Companion to letrec-values4: a closure enclosing a plain let-values whose
+;; binding expression captures a free variable (base). Confirms free-variable
+;; analysis walks let-values binding expressions in the enclosing scope.
+(linklet () ()
+  (let-values ([(make) (lambda (base)
+                         (let-values ([(f) (lambda (n) (+ n base))])
+                           (f 10)))])
+    (make 5)))

--- a/test/integration/letrec-values.rkt
+++ b/test/integration/letrec-values.rkt
@@ -1,0 +1,8 @@
+;; RUN: norac %s | FileCheck %s
+;; CHECK: 20
+;; Unlike let-values, a letrec-values binding is in scope for the binding
+;; expressions that follow it, so y's expression can refer to x.
+(linklet () ()
+  (letrec-values ([(x) 5]
+                  [(y) (+ x 10)])
+    (+ x y)))

--- a/test/integration/letrec-values1.rkt
+++ b/test/integration/letrec-values1.rkt
@@ -1,0 +1,8 @@
+;; RUN: norac %s | FileCheck %s
+;; CHECK: 105
+;; A closure created in an earlier clause can refer to an identifier bound by a
+;; later clause; the reference resolves when the closure is applied.
+(linklet () ()
+  (letrec-values ([(f) (lambda (n) (+ n c))]
+                  [(c) 100])
+    (f 5)))

--- a/test/integration/letrec-values2.rkt
+++ b/test/integration/letrec-values2.rkt
@@ -1,0 +1,7 @@
+;; RUN: norac %s | FileCheck %s
+;; CHECK: 7
+;; Mutually referring closures: f calls g, which is bound in a later clause.
+(linklet () ()
+  (letrec-values ([(f) (lambda (n) (g n))]
+                  [(g) (lambda (n) (+ n 2))])
+    (f 5)))

--- a/test/integration/letrec-values3.rkt
+++ b/test/integration/letrec-values3.rkt
@@ -1,0 +1,8 @@
+;; RUN: norac %s | FileCheck %s
+;; CHECK: 6
+;; A multiple-values clause binds several identifiers at once, and a later
+;; clause can refer to them.
+(linklet () ()
+  (letrec-values ([(a b) (values 1 2)]
+                  [(c) (+ a b)])
+    (+ c (+ a b))))

--- a/test/integration/letrec-values4.rkt
+++ b/test/integration/letrec-values4.rkt
@@ -1,0 +1,11 @@
+;; RUN: norac %s | FileCheck %s
+;; CHECK: 15
+;; A closure encloses a letrec-values whose binding expression captures a free
+;; variable (base) from the surrounding lambda. This exercises free-variable
+;; analysis over the letrec binding expressions, so the closure built for the
+;; inner letrec captures base correctly.
+(linklet () ()
+  (let-values ([(make) (lambda (base)
+                         (letrec-values ([(f) (lambda (n) (+ n base))])
+                           (f 10)))])
+    (make 5)))

--- a/test/unit/test_parse.cpp
+++ b/test/unit/test_parse.cpp
@@ -232,6 +232,22 @@ TEST_CASE("Lexing full expressions 2", "[parser]") {
   REQUIRE(Tok.is(Tok::TokType::RPAREN));
 }
 
+TEST_CASE("Lexing letrec-values", "[parser]") {
+  SourceStream Letvals("(letrec-values () #f)");
+  Tok Tok = gettok(Letvals);
+  REQUIRE(Tok.is(Tok::TokType::LPAREN));
+  Tok = gettok(Letvals);
+  REQUIRE(Tok.is(Tok::TokType::LETREC_VALUES));
+  Tok = gettok(Letvals);
+  REQUIRE(Tok.is(Tok::TokType::LPAREN));
+  Tok = gettok(Letvals);
+  REQUIRE(Tok.is(Tok::TokType::RPAREN));
+  Tok = gettok(Letvals);
+  REQUIRE(Tok.is(Tok::TokType::BOOL_FALSE));
+  Tok = gettok(Letvals);
+  REQUIRE(Tok.is(Tok::TokType::RPAREN));
+}
+
 TEST_CASE("Lexing Characters", "[parser]") {
   SourceStream Char1(R"(#\space)");
   Tok Tok = gettok(Char1);


### PR DESCRIPTION
## Summary

- Teach the interpreter to evaluate `letrec-values`, whose bindings are in scope for both the binding expressions and the body (enabling recursion and mutual recursion), unlike `let-values` whose expressions evaluate in the enclosing scope.
- `letrec-values` reuses the existing `LetValues` AST node and `parseLetValues`, distinguished by a new `Rec` flag; the parser accepts the already-lexed `letrec-values` keyword.
- The interpreter pushes a fresh environment and fills it in left to right, keeping it live on the stack while the binding expressions and body evaluate, so clauses can refer to earlier and later bindings the way top-level recursive definitions already do.
- Free-variable analysis now also walks the binding expressions (previously only the body), shadowing the bound identifiers for `letrec-values` but not for `let-values`, so closures enclosing either form capture the correct variables.

Fixes #8

## Test plan

- [x] `ctest --preset debug` — 14 unit tests pass (adds a `letrec-values` lexing test)
- [x] `nora-lit test/integration` — 52 integration tests pass (adds 4 `letrec-values` `.rkt` tests: sequential binding, closure over a later binding, mutual reference, multiple-values clause)
- [x] `clang-format --dry-run --Werror` on changed files — clean
- [x] Debug build is warning-clean (warnings-as-errors)