### PR TITLE
Interpret case-lambda

### DIFF
--- a/src/AST.cpp
+++ b/src/AST.cpp
@@ -238,6 +238,30 @@ void Lambda::dump() const {
 void Lambda::write() const { std::cout << "#<procedure>"; }
 
 //
+// Implementation of CaseLambda node.
+//
+
+CaseLambda::CaseLambda(CaseLambda const &CL)
+    : ClonableNode(ASTNodeKind::AST_CaseLambda) {
+  Clauses.reserve(CL.Clauses.size());
+  for (auto const &C : CL.Clauses) {
+    Clauses.push_back(
+        std::unique_ptr<Lambda>(static_cast<Lambda *>(C->clone())));
+  }
+}
+
+void CaseLambda::dump() const {
+  llvm::dbgs() << "(case-lambda";
+  for (auto const &C : Clauses) {
+    llvm::dbgs() << " ";
+    C->dump();
+  }
+  llvm::dbgs() << ")";
+}
+
+void CaseLambda::write() const { std::cout << "#<procedure>"; }
+
+//
 // Implementation of DefineValues node.
 //
 DefineValues::DefineValues(const DefineValues &DV)

--- a/src/ASTRuntime.cpp
+++ b/src/ASTRuntime.cpp
@@ -43,3 +43,42 @@ void Closure::dump() const {
   llvm::dbgs() << "<closure: not implemented>\n";
 }
 void Closure::write() const {}
+
+CaseLambdaClosure::CaseLambdaClosure(const CaseLambda &CLbd,
+                                     const std::vector<Environment> &Envs)
+    : ClonableNode(ASTNodeKind::AST_CaseLambdaClosure),
+      CL(std::unique_ptr<CaseLambda>(static_cast<CaseLambda *>(CLbd.clone()))) {
+
+  // Capture the free variables across all clauses, mirroring Closure.
+
+  // 1. Find the free variables in the case-lambda.
+  AnalysisFreeVars AFV;
+  CL->accept(AFV);
+  auto const &FreeVars = AFV.getResult();
+
+  // 2. Find in the current environment, the values of the free variables
+  // and save them.
+  for (auto const &Var : FreeVars) {
+    for (auto const &E : llvm::reverse(Envs)) {
+      auto const &Val = E.lookup(Var);
+      if (Val) {
+        Env.add(Var, std::unique_ptr<ValueNode>(Val->clone()));
+        break;
+      }
+    }
+  }
+}
+
+CaseLambdaClosure::CaseLambdaClosure(const CaseLambdaClosure &Other)
+    : ClonableNode(ASTNodeKind::AST_CaseLambdaClosure),
+      CL(std::unique_ptr<CaseLambda>(
+          static_cast<CaseLambda *>(Other.CL->clone()))) {
+  for (auto const &E : Other.Env) {
+    Env.add(E.first, std::unique_ptr<ValueNode>(E.second->clone()));
+  }
+}
+
+void CaseLambdaClosure::dump() const {
+  llvm::dbgs() << "<case-lambda closure: not implemented>\n";
+}
+void CaseLambdaClosure::write() const {}

--- a/src/AnalysisFreeVars.cpp
+++ b/src/AnalysisFreeVars.cpp
@@ -66,8 +66,21 @@ void AnalysisFreeVars::visit(ast::Lambda const &L) {
   Vars.pop_back();
 }
 
+void AnalysisFreeVars::visit(ast::CaseLambda const &CL) {
+  // A case-lambda's free variables are the union over all its clauses. Each
+  // clause is a Lambda that binds its own formals around its own body.
+  for (size_t Idx = 0; Idx < CL.size(); ++Idx) {
+    CL[Idx].accept(*this);
+  }
+}
+
 void AnalysisFreeVars::visit(ast::Closure const &L) {
   // Closures by definition do not have free variables.
+  // Nothing to do.
+}
+
+void AnalysisFreeVars::visit(ast::CaseLambdaClosure const &CL) {
+  // Case-lambda closures by definition do not have free variables.
   // Nothing to do.
 }
 

--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -180,6 +180,18 @@ void Interpreter::visit(ast::Closure const &C) {
   Result = std::unique_ptr<ast::ValueNode>(C.clone());
 }
 
+void Interpreter::visit(ast::CaseLambda const &CL) {
+  // The interpretation of a case-lambda expression is a closure,
+  // even if no variables are captured.
+  LLVM_DEBUG(llvm::dbgs() << "Interpreting CaseLambda\n");
+  Result = std::make_unique<ast::CaseLambdaClosure>(CL, Envs);
+}
+
+void Interpreter::visit(ast::CaseLambdaClosure const &C) {
+  LLVM_DEBUG(llvm::dbgs() << "Interpreting CaseLambdaClosure\n");
+  Result = std::unique_ptr<ast::ValueNode>(C.clone());
+}
+
 void Interpreter::visit(ast::Begin const &B) {
   LLVM_DEBUG(llvm::dbgs() << "Interpreting Begin\n");
 
@@ -215,15 +227,76 @@ void Interpreter::visit(ast::Vector const &Vec) {
   Result = std::unique_ptr<ast::ValueNode>(Vec.clone());
 }
 
+// Returns true if the formals F accept NArgs supplied arguments.
+static bool formalsAccept(const ast::Formal &F, size_t NArgs) {
+  switch (F.getType()) {
+  case ast::Formal::Type::List:
+    return static_cast<const ast::ListFormal &>(F).size() == NArgs;
+  case ast::Formal::Type::ListRest:
+    return static_cast<const ast::ListRestFormal &>(F).size() <= NArgs;
+  case ast::Formal::Type::Identifier:
+    return true;
+  }
+  llvm_unreachable("unknown formal type");
+}
+
+void Interpreter::applyFormals(
+    const ast::Formal &F, const ast::ExprNode &Body,
+    const Environment &CapturedEnv,
+    std::vector<std::unique_ptr<ast::ValueNode>> &Args) {
+  // Create an environment where each argument is bound to the corresponding
+  // value. Then evaluate the body in this environment.
+  Environment Env;
+  if (F.getType() == ast::Formal::Type::List) {
+    auto LF = static_cast<const ast::ListFormal &>(F);
+    for (size_t Idx = 0; Idx < Args.size(); ++Idx) {
+      Env.add(LF[Idx], std::move(Args[Idx]));
+    }
+  } else if (F.getType() == ast::Formal::Type::ListRest) {
+    auto LRF = static_cast<const ast::ListRestFormal &>(F);
+    size_t Idx = 0;
+    for (; Idx < LRF.size(); ++Idx) {
+      Env.add(LRF[Idx], std::move(Args[Idx]));
+    }
+    // Create a list of the remaining arguments.
+    auto L = std::make_unique<ast::List>();
+    for (; Idx < Args.size(); ++Idx) {
+      L->appendExpr(std::move(Args[Idx]));
+    }
+    Env.add(LRF.getRestFormal(), std::unique_ptr<ast::ValueNode>(L->clone()));
+  } else if (F.getType() == ast::Formal::Type::Identifier) {
+    auto IF = static_cast<const ast::IdentifierFormal &>(F);
+    auto L = std::make_unique<ast::List>();
+    for (size_t Idx = 0; Idx < Args.size(); ++Idx) {
+      L->appendExpr(std::move(Args[Idx]));
+    }
+    Env.add(IF.getIdentifier(), std::unique_ptr<ast::ValueNode>(L->clone()));
+  } else {
+    llvm_unreachable("unknown formal type");
+  }
+
+  Envs.push_back(CapturedEnv); // Pushes the closure environment first.
+  Envs.push_back(Env);         // Then pushes the environment with the args.
+
+  Body.accept(*this);
+
+  Envs.pop_back();
+  Envs.pop_back();
+}
+
 void Interpreter::visit(ast::Application const &A) {
   // 1. Evaluate the first expression.
   // which should evaluate to a lambda expression.
   A[0].accept(*this);
   std::unique_ptr<ast::ValueNode> D = std::move(Result);
 
-  // Error out if not a Closure expression or Runtime expression.
+  // Error out if not a Closure, CaseLambdaClosure, or Runtime function.
   std::unique_ptr<ast::Closure> C = dyn_castU<ast::Closure>(D);
+  std::unique_ptr<ast::CaseLambdaClosure> CLC;
   if (!C) {
+    CLC = dyn_castU<ast::CaseLambdaClosure>(D);
+  }
+  if (!C && !CLC) {
     // maybe a runtime function?
     std::unique_ptr<ast::RuntimeFunction> RF =
         dyn_castU<ast::RuntimeFunction>(D);
@@ -276,70 +349,50 @@ void Interpreter::visit(ast::Application const &A) {
     assert(Result && "Expected result from expression.");
     Args.emplace_back(std::move(Result));
   }
+  // 3. Single-clause closure: check arity and apply.
   // If we have a list formals then, error out of args diff than formals.
   // If we have a list rest formals then, error out if args less than formals.
   // If it's identifier formals then it does not matter.
-  const ast::Lambda &L = C->getLambda();
-  const ast::Formal &F = L.getFormals();
-  if (F.getType() == ast::Formal::Type::List) {
-    auto LF = static_cast<const ast::ListFormal &>(F);
-    if (Args.size() != LF.size()) {
-      std::cerr << "Expected " << LF.size() << " arguments, got " << Args.size()
-                << std::endl;
-      Result = nullptr;
-      return;
+  if (C) {
+    const ast::Lambda &L = C->getLambda();
+    const ast::Formal &F = L.getFormals();
+    if (F.getType() == ast::Formal::Type::List) {
+      auto LF = static_cast<const ast::ListFormal &>(F);
+      if (Args.size() != LF.size()) {
+        std::cerr << "Expected " << LF.size() << " arguments, got "
+                  << Args.size() << std::endl;
+        Result = nullptr;
+        return;
+      }
+    } else if (F.getType() == ast::Formal::Type::ListRest) {
+      auto LRF = static_cast<const ast::ListRestFormal &>(F);
+      if (Args.size() < LRF.size()) {
+        std::cerr << "Expected at least " << LRF.size() << " arguments, got "
+                  << Args.size() << std::endl;
+        Result = nullptr;
+        return;
+      }
     }
-  } else if (F.getType() == ast::Formal::Type::ListRest) {
-    auto LRF = static_cast<const ast::ListRestFormal &>(F);
-    if (Args.size() < LRF.size()) {
-      std::cerr << "Expected at least " << LRF.size() << " arguments, got "
-                << Args.size() << std::endl;
-      Result = nullptr;
+
+    applyFormals(F, L.getBody(), C->getEnvironment(), Args);
+    return;
+  }
+
+  // 4. Case-lambda closure: apply the first clause whose formals accept the
+  // number of supplied arguments.
+  const ast::CaseLambda &CL = CLC->getCaseLambda();
+  for (size_t Idx = 0; Idx < CL.size(); ++Idx) {
+    const ast::Lambda &Clause = CL[Idx];
+    if (formalsAccept(Clause.getFormals(), Args.size())) {
+      applyFormals(Clause.getFormals(), Clause.getBody(), CLC->getEnvironment(),
+                   Args);
       return;
     }
   }
 
-  // 3. Apply the lambda expression to the evaluated expressions.
-  // Create an environment where each argument is bound to the corresponding
-  // value. Then evaluate the lambda body in this environment.
-  Environment Env;
-  if (F.getType() == ast::Formal::Type::List) {
-    auto LF = static_cast<const ast::ListFormal &>(F);
-    for (size_t Idx = 0; Idx < Args.size(); ++Idx) {
-      Env.add(LF[Idx], std::move(Args[Idx]));
-    }
-  } else if (F.getType() == ast::Formal::Type::ListRest) {
-    auto LRF = static_cast<const ast::ListRestFormal &>(F);
-    size_t Idx = 0;
-    for (; Idx < LRF.size(); ++Idx) {
-      Env.add(LRF[Idx], std::move(Args[Idx]));
-    }
-    // Create a list of the remaining arguments.
-    auto L = std::make_unique<ast::List>();
-    for (; Idx < Args.size(); ++Idx) {
-      L->appendExpr(std::move(Args[Idx]));
-    }
-
-    Env.add(LRF.getRestFormal(), std::unique_ptr<ast::ValueNode>(L->clone()));
-  } else if (F.getType() == ast::Formal::Type::Identifier) {
-    auto IF = static_cast<const ast::IdentifierFormal &>(F);
-    auto L = std::make_unique<ast::List>();
-    for (size_t Idx = 0; Idx < Args.size(); ++Idx) {
-      L->appendExpr(std::move(Args[Idx]));
-    }
-    Env.add(IF.getIdentifier(), std::unique_ptr<ast::ValueNode>(L->clone()));
-  } else {
-    llvm_unreachable("unknown formal type");
-  }
-
-  Envs.push_back(C->getEnvironment()); // Pushes the closure environment first.
-  Envs.push_back(Env); // Then pushes the environment with the args.
-
-  // 4. Return the result of the application.
-  L.getBody().accept(*this);
-
-  Envs.pop_back();
-  Envs.pop_back();
+  std::cerr << "case-lambda: no matching clause for " << Args.size()
+            << " arguments" << std::endl;
+  Result = nullptr;
 }
 
 // To interpret a set! expression we set the value of the identifier in the

--- a/src/Parse.cpp
+++ b/src/Parse.cpp
@@ -58,7 +58,7 @@ using namespace Lex;
 //
 // expr := <id>                                             - parseIdentifier
 //       | (lambda <formals> <expr>)                        - parseLambda
-//       | (case-lambda (<formals> <expr>) ...)
+//       | (case-lambda (<formals> <expr>) ...)             - parseCaseLambda
 //       | (if <expr> <expr> <expr>)                        - parseIfCond
 //       | (begin <expr> ...+)                              - parseBegin
 //       | (begin0 <expr> ...+)                             - parseBegin
@@ -199,6 +199,11 @@ std::unique_ptr<ast::ExprNode> Parse::parseExpr(SourceStream &S) {
   std::unique_ptr<ast::Lambda> L = parseLambda(S);
   if (L) {
     return L;
+  }
+
+  std::unique_ptr<ast::CaseLambda> CL = parseCaseLambda(S);
+  if (CL) {
+    return CL;
   }
 
   std::unique_ptr<ast::Begin> B = parseBegin(S);
@@ -619,6 +624,65 @@ std::unique_ptr<ast::Lambda> Parse::parseLambda(SourceStream &S) {
   }
 
   return Lambda;
+}
+
+// Parse case-lambda expression of the form:
+// (case-lambda (<formals> <expr>) ...)
+std::unique_ptr<ast::CaseLambda> Parse::parseCaseLambda(SourceStream &S) {
+  size_t Start = S.getPosition();
+
+  Tok T = gettok(S);
+  if (!T.is(Tok::TokType::LPAREN)) {
+    S.rewindTo(Start);
+    return nullptr;
+  }
+
+  T = gettok(S);
+  if (!T.is(Tok::TokType::CASE_LAMBDA)) {
+    S.rewindTo(Start);
+    return nullptr;
+  }
+
+  auto CaseLambda = std::make_unique<ast::CaseLambda>();
+
+  // Parse zero or more clauses of the form ( <formals> <expr> ).
+  while (true) {
+    T = gettok(S);
+    if (T.is(Tok::TokType::RPAREN)) {
+      break; // End of the case-lambda.
+    }
+    if (!T.is(Tok::TokType::LPAREN)) {
+      S.rewindTo(Start);
+      return nullptr;
+    }
+
+    // Each clause reuses the lambda machinery: formals plus a single body.
+    auto Clause = std::make_unique<ast::Lambda>();
+
+    std::unique_ptr<ast::Formal> Formals = parseFormals(S);
+    if (!Formals) {
+      S.rewindTo(Start);
+      return nullptr;
+    }
+    Clause->setFormals(std::move(Formals));
+
+    std::unique_ptr<ast::ExprNode> Body = parseExpr(S);
+    if (!Body) {
+      S.rewindTo(Start);
+      return nullptr;
+    }
+    Clause->setBody(std::move(Body));
+
+    T = gettok(S);
+    if (!T.is(Tok::TokType::RPAREN)) {
+      S.rewindTo(Start);
+      return nullptr;
+    }
+
+    CaseLambda->addClause(std::move(Clause));
+  }
+
+  return CaseLambda;
 }
 
 // Parse formals of the form:

--- a/src/include/AST.h
+++ b/src/include/AST.h
@@ -43,6 +43,8 @@ public:
     AST_SetBang,
     First_ValueNode, // all ValueNodes must be after this
     AST_BooleanLiteral,
+    AST_CaseLambda,
+    AST_CaseLambdaClosure, // result of evaluating a CaseLambda expression
     AST_Char,
     AST_Closure, // result of evaluating a Lambda expression
     AST_Integer,
@@ -592,6 +594,33 @@ public:
 private:
   std::unique_ptr<Formal> Formals;
   std::unique_ptr<ExprNode> Body;
+};
+
+// A case-lambda is a sequence of lambda clauses. When applied, the first
+// clause whose formals accept the number of supplied arguments is selected.
+// Defined in terms of Lambda, so it is placed right after it.
+class CaseLambda : public ClonableNode<CaseLambda, ValueNode> {
+public:
+  CaseLambda() : ClonableNode(ASTNodeKind::AST_CaseLambda) {}
+  CaseLambda(CaseLambda const &CL);
+  CaseLambda(CaseLambda &&CL) = default;
+  ~CaseLambda() = default;
+
+  void addClause(std::unique_ptr<Lambda> C) { Clauses.push_back(std::move(C)); }
+  [[nodiscard]] size_t size() const { return Clauses.size(); }
+  [[nodiscard]] Lambda const &operator[](size_t Idx) const {
+    return *Clauses[Idx];
+  }
+
+  LLVM_DUMP_METHOD void dump() const override;
+  void write() const override;
+
+  static bool classof(const ASTNode *N) {
+    return N->getKind() == ASTNodeKind::AST_CaseLambda;
+  }
+
+private:
+  llvm::SmallVector<std::unique_ptr<Lambda>> Clauses;
 };
 
 class LetValues : public ClonableNode<LetValues, ExprNode> {

--- a/src/include/ASTRuntime.h
+++ b/src/include/ASTRuntime.h
@@ -33,4 +33,25 @@ private:
   Environment Env;
 };
 
+// A CaseLambdaClosure is the runtime manifestation of a CaseLambda.
+class CaseLambdaClosure : public ClonableNode<CaseLambdaClosure, ValueNode> {
+public:
+  CaseLambdaClosure(const CaseLambda &CL, const std::vector<Environment> &Envs);
+  CaseLambdaClosure(const CaseLambdaClosure &Other);
+
+  static bool classof(const ASTNode *N) {
+    return N->getKind() == ASTNodeKind::AST_CaseLambdaClosure;
+  }
+
+  LLVM_DUMP_METHOD void dump() const override;
+  void write() const override;
+
+  const CaseLambda &getCaseLambda() const { return *CL; }
+  const Environment &getEnvironment() const { return Env; }
+
+private:
+  std::unique_ptr<CaseLambda> CL;
+  Environment Env;
+};
+
 }; // namespace ast

--- a/src/include/ASTVisitor.h
+++ b/src/include/ASTVisitor.h
@@ -11,6 +11,8 @@ public:
   virtual void visit(ast::Application const &A) = 0;
   virtual void visit(ast::Begin const &B) = 0;
   virtual void visit(ast::BooleanLiteral const &Bool) = 0;
+  virtual void visit(ast::CaseLambda const &CL) = 0;
+  virtual void visit(ast::CaseLambdaClosure const &CL) = 0;
   virtual void visit(ast::Char const &C) = 0;
   virtual void visit(ast::Closure const &L) = 0;
   virtual void visit(ast::DefineValues const &DV) = 0;

--- a/src/include/AST_fwd.h
+++ b/src/include/AST_fwd.h
@@ -5,6 +5,8 @@ namespace ast {
 class Application;
 class Begin;
 class BooleanLiteral;
+class CaseLambda;
+class CaseLambdaClosure;
 class Char;
 class Closure;
 class DefineValues;

--- a/src/include/AnalysisFreeVars.h
+++ b/src/include/AnalysisFreeVars.h
@@ -19,6 +19,8 @@ public:
   virtual void visit(ast::Application const &A) override;
   virtual void visit(ast::Begin const &B) override;
   virtual void visit(ast::BooleanLiteral const &Bool) override;
+  virtual void visit(ast::CaseLambda const &CL) override;
+  virtual void visit(ast::CaseLambdaClosure const &CL) override;
   virtual void visit(ast::Char const &C) override;
   virtual void visit(ast::Closure const &L) override;
   virtual void visit(ast::DefineValues const &DV) override;

--- a/src/include/Interpreter.h
+++ b/src/include/Interpreter.h
@@ -23,6 +23,8 @@ public:
   virtual void visit(ast::Application const &A) override;
   virtual void visit(ast::Begin const &B) override;
   virtual void visit(ast::BooleanLiteral const &Bool) override;
+  virtual void visit(ast::CaseLambda const &CL) override;
+  virtual void visit(ast::CaseLambdaClosure const &CL) override;
   virtual void visit(ast::Char const &C) override;
   virtual void visit(ast::Closure const &L) override;
   virtual void visit(ast::DefineValues const &DV) override;
@@ -57,6 +59,13 @@ public:
   }
 
 private:
+  // Binds Args to the formals F in a fresh environment, then evaluates Body
+  // with CapturedEnv and that environment pushed, leaving the value in Result.
+  // Precondition: F accepts Args.size() arguments.
+  void applyFormals(const ast::Formal &F, const ast::ExprNode &Body,
+                    const Environment &CapturedEnv,
+                    std::vector<std::unique_ptr<ast::ValueNode>> &Args);
+
   std::vector<Environment> Envs;          /// Environment map for identifiers.
   std::unique_ptr<ast::ValueNode> Result; /// Result of the last evaluation.
 };

--- a/src/include/Parse.h
+++ b/src/include/Parse.h
@@ -32,6 +32,7 @@ bool isSpecialInitial(SourceStream &S, size_t Offset = 0);
 std::unique_ptr<ast::Application> parseApplication(SourceStream &S);
 std::unique_ptr<ast::Begin> parseBegin(SourceStream &S);
 std::unique_ptr<ast::BooleanLiteral> parseBooleanLiteral(SourceStream &S);
+std::unique_ptr<ast::CaseLambda> parseCaseLambda(SourceStream &S);
 std::unique_ptr<ast::Char> parseChar(SourceStream &S);
 std::unique_ptr<ast::DefineValues> parseDefineValues(SourceStream &S);
 std::unique_ptr<ast::ExprNode> parseExpr(SourceStream &S);

--- a/test/integration/case-lambda.rkt
+++ b/test/integration/case-lambda.rkt
@@ -1,0 +1,3 @@
+;; RUN: norac %s | FileCheck %s
+;; CHECK: 2
+(linklet () () ((case-lambda ((x) x) ((x y) (+ x y))) 2))

--- a/test/integration/case-lambda1.rkt
+++ b/test/integration/case-lambda1.rkt
@@ -1,0 +1,4 @@
+;; RUN: norac %s | FileCheck %s
+;; The clause selected depends on the number of arguments.
+;; CHECK: 7
+(linklet () () ((case-lambda ((x) x) ((x y) (+ x y))) 3 4))

--- a/test/integration/case-lambda2.rkt
+++ b/test/integration/case-lambda2.rkt
@@ -1,0 +1,4 @@
+;; RUN: norac %s | FileCheck %s
+;; A clause with a rest formal collects the extra arguments into a list.
+;; CHECK: (2 3)
+(linklet () () ((case-lambda ((x) x) ((x . y) y)) 1 2 3))

--- a/test/integration/case-lambda3.rkt
+++ b/test/integration/case-lambda3.rkt
@@ -1,0 +1,5 @@
+;; RUN: norac %s | FileCheck %s
+;; An identifier formal accepts any number of arguments as a list, so it acts
+;; as the fallthrough clause after the fixed-arity clauses.
+;; CHECK: (1 2)
+(linklet () () ((case-lambda (() 0) (args args)) 1 2))

--- a/test/integration/case-lambda4.rkt
+++ b/test/integration/case-lambda4.rkt
@@ -1,0 +1,8 @@
+;; RUN: norac %s | FileCheck %s
+;; A case-lambda captures its free variables across every clause.
+;; CHECK: 15
+(linklet () ()
+  (define-values (f) (values 0))
+  (let-values (((n) (values 10)))
+    (set! f (case-lambda ((x) (+ x n)) ((x y) (+ x y n)))))
+  (f 5))

--- a/test/unit/test_parse.cpp
+++ b/test/unit/test_parse.cpp
@@ -294,6 +294,28 @@ TEST_CASE("Parsing lambdas", "[parser]") {
   REQUIRE(Var.getName() == "x");
 }
 
+TEST_CASE("Parsing case-lambda", "[parser]") {
+  SourceStream CL1("(case-lambda ((x) x) ((x y) (+ x y)))");
+  std::unique_ptr<ast::CaseLambda> CL = parseCaseLambda(CL1);
+  REQUIRE(CL);
+  REQUIRE(CL->size() == 2);
+  REQUIRE((*CL)[0].getFormalsType() == ast::Formal::Type::List);
+  REQUIRE((*CL)[1].getFormalsType() == ast::Formal::Type::List);
+
+  // A clause may use a rest formal.
+  SourceStream CL2("(case-lambda ((x) x) ((x . y) y))");
+  CL = parseCaseLambda(CL2);
+  REQUIRE(CL);
+  REQUIRE(CL->size() == 2);
+  REQUIRE((*CL)[1].getFormalsType() == ast::Formal::Type::ListRest);
+
+  // A case-lambda with no clauses is valid.
+  SourceStream CL3("(case-lambda)");
+  CL = parseCaseLambda(CL3);
+  REQUIRE(CL);
+  REQUIRE(CL->size() == 0);
+}
+
 TEST_CASE("Parsing begin", "[parser]") {
   SourceStream B1("(begin 1 2 3)");
   std::unique_ptr<ast::Begin> B = parseBegin(B1);


### PR DESCRIPTION
## Summary

- Add a `CaseLambda` AST node (a sequence of `lambda` clauses) and a `CaseLambdaClosure` runtime value, so `(case-lambda (formals body) ...)` parses, evaluates to a closure, and captures free variables across all clauses.
- Application now selects the first clause whose formals accept the supplied argument count (exact match for a fixed list, `>=` for a rest formal, any count for a bare identifier), then binds and evaluates that clause's body.
- The clause-binding logic that `lambda` and `case-lambda` share is factored into an `Interpreter::applyFormals` helper; clause selection uses a small `formalsAccept` predicate.

Fixes #3

## Test plan

- [x] `ctest --preset debug` — 14/14 unit tests pass, including a new `Parsing case-lambda` case (fixed, rest, and empty-clause forms)
- [x] `nora-lit test/integration` — 53/53 pass, including 5 new `case-lambda*.rkt` tests: arity dispatch, rest-formal clause, identifier (all-args) fallthrough clause, and free-variable capture with `set!`/`let-values`
- [x] `cmake --build --preset debug` — clean (warnings-as-errors)
- [x] `clang-format` (v22.1.5) — all edited files clean