### PR TITLE
Add diff-scoped clang-tidy CI workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,10 +2,10 @@
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 #
 # The only tracked ecosystem is GitHub Actions: the workflow actions are pinned
-# to commit SHAs, and Dependabot keeps those pins (and the version comments)
-# current. The C++/CMake dependencies (LLVM, MLIR, GMP) are provided by the
-# system toolchain and Catch2 is fetched by CMake FetchContent, so there is no
-# package manifest for Dependabot to track.
+# to release tags, and Dependabot bumps them when new releases are published.
+# The C++/CMake dependencies (LLVM, MLIR, GMP) are provided by the system
+# toolchain and Catch2 is fetched by CMake FetchContent, so there is no package
+# manifest for Dependabot to track.
 version: 2
 updates:
   - package-ecosystem: "github-actions"

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,80 @@
+name: ClangTidy
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '**.cpp'
+      - '**.cc'
+      - '**.h'
+      - '**.hpp'
+      - '**.inc'
+      - '.clang-tidy'
+      - '.github/workflows/clang-tidy.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: clang-tidy-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  LLVM_VERSION: "22"
+  CMAKE_PREFIX_PATH: /usr/lib/llvm-22
+  # clang-tidy is a Clang tool, so the compile database must carry
+  # Clang-compatible flags; configuring with GCC leaks GCC-only warning
+  # options that clang-tidy then rejects as unknown-warning-option errors.
+  CC: clang-22
+  CXX: clang++-22
+
+jobs:
+  clang-tidy:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Install LLVM ${{ env.LLVM_VERSION }}
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh "$LLVM_VERSION"
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build libgmp-dev \
+            "clang-${LLVM_VERSION}" "clang-tidy-${LLVM_VERSION}" \
+            "clang-tools-${LLVM_VERSION}" "llvm-${LLVM_VERSION}-dev" \
+            "llvm-${LLVM_VERSION}-tools"
+          echo "/usr/lib/llvm-${LLVM_VERSION}/bin" >> "$GITHUB_PATH"
+
+      # Only configure: CMAKE_EXPORT_COMPILE_COMMANDS (set by the preset) writes
+      # build/debug/compile_commands.json and configure_file generates config.h,
+      # which is all clang-tidy needs. Building is unnecessary for a lint pass.
+      - name: Configure (generate compile_commands.json)
+        run: cmake --preset debug
+
+      # Diff-scoped so the ruleset applies to new/changed lines without drowning
+      # the PR in pre-existing findings from unchanged code. clang-tidy-diff.py
+      # ships with the clang-tidy package; -warnings-as-errors makes any finding
+      # on a changed line fail the job via the script's exit code.
+      - name: Run clang-tidy on changed lines
+        run: |
+          BASE_REF="${GITHUB_BASE_REF:-main}"
+          DIFF_SCRIPT="$(find "/usr/lib/llvm-${LLVM_VERSION}" -name clang-tidy-diff.py | head -n1)"
+          if [ -z "$DIFF_SCRIPT" ]; then
+            echo "::error::clang-tidy-diff.py not found in the LLVM ${LLVM_VERSION} installation"
+            exit 1
+          fi
+          echo "Linting changes relative to origin/${BASE_REF} with ${DIFF_SCRIPT}"
+          git diff -U0 "origin/${BASE_REF}...HEAD" -- '*.cpp' '*.cc' '*.h' '*.hpp' '*.inc' \
+            | python3 "$DIFF_SCRIPT" \
+                -clang-tidy-binary "clang-tidy-${LLVM_VERSION}" \
+                -path build/debug -p1 -j "$(nproc)" \
+                -warnings-as-errors='*'

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -64,6 +64,12 @@ jobs:
       # the PR in pre-existing findings from unchanged code. clang-tidy-diff.py
       # ships with the clang-tidy package; -warnings-as-errors makes any finding
       # on a changed line fail the job via the script's exit code.
+      #
+      # -only-check-in-db limits the lint to files present in the compile
+      # database. The debug preset omits src/mlir (opt-in behind NORA_ENABLE_MLIR,
+      # and its MLIR/TableGen deps are not installed here), so without this flag a
+      # PR touching src/mlir/*.cpp would be linted with no compile command and
+      # fail on missing mlir/IR/... and generated .inc headers.
       - name: Run clang-tidy on changed lines
         run: |
           BASE_REF="${GITHUB_BASE_REF:-main}"
@@ -77,4 +83,5 @@ jobs:
             | python3 "$DIFF_SCRIPT" \
                 -clang-tidy-binary "clang-tidy-${LLVM_VERSION}" \
                 -path build/debug -p1 -j "$(nproc)" \
+                -only-check-in-db \
                 -warnings-as-errors='*'

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -65,11 +65,14 @@ jobs:
       # ships with the clang-tidy package; -warnings-as-errors makes any finding
       # on a changed line fail the job via the script's exit code.
       #
-      # -only-check-in-db limits the lint to files present in the compile
-      # database. The debug preset omits src/mlir (opt-in behind NORA_ENABLE_MLIR,
-      # and its MLIR/TableGen deps are not installed here), so without this flag a
-      # PR touching src/mlir/*.cpp would be linted with no compile command and
-      # fail on missing mlir/IR/... and generated .inc headers.
+      # src/mlir is excluded via the git pathspec: it is opt-in behind
+      # NORA_ENABLE_MLIR (absent from the debug compile DB, and its MLIR/TableGen
+      # deps are not installed here), so linting it would fail on missing
+      # mlir/IR/... and generated .inc headers. Everything else is checked,
+      # including changed headers — clang-tidy lints those by borrowing a real
+      # translation unit's compile command (inferMissingCompileCommands). A
+      # blunter -only-check-in-db would also skip headers, silently leaving
+      # header-only PRs unlinted.
       - name: Run clang-tidy on changed lines
         run: |
           BASE_REF="${GITHUB_BASE_REF:-main}"
@@ -79,9 +82,9 @@ jobs:
             exit 1
           fi
           echo "Linting changes relative to origin/${BASE_REF} with ${DIFF_SCRIPT}"
-          git diff -U0 "origin/${BASE_REF}...HEAD" -- '*.cpp' '*.cc' '*.h' '*.hpp' '*.inc' \
+          git diff -U0 "origin/${BASE_REF}...HEAD" \
+              -- '*.cpp' '*.cc' '*.h' '*.hpp' '*.inc' ':(exclude)src/mlir/*' \
             | python3 "$DIFF_SCRIPT" \
                 -clang-tidy-binary "clang-tidy-${LLVM_VERSION}" \
                 -path build/debug -p1 -j "$(nproc)" \
-                -only-check-in-db \
                 -warnings-as-errors='*'

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -54,6 +54,14 @@ jobs:
             "llvm-${LLVM_VERSION}-tools"
           echo "/usr/lib/llvm-${LLVM_VERSION}/bin" >> "$GITHUB_PATH"
 
+      # Validate the ruleset itself. .clang-tidy is in the paths filter, but the
+      # diff-scoped lint below sees an empty patch on a config-only PR, so without
+      # this a malformed .clang-tidy could merge green and break the next source
+      # PR. --verify-config reads ./.clang-tidy, needs no compile database, and is
+      # instant.
+      - name: Verify clang-tidy config
+        run: clang-tidy-${LLVM_VERSION} --verify-config
+
       # Only configure: CMAKE_EXPORT_COMPILE_COMMANDS (set by the preset) writes
       # build/debug/compile_commands.json and configure_file generates config.h,
       # which is all clang-tidy needs. Building is unnecessary for a lint pass.

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -25,7 +25,7 @@ jobs:
   coverage:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@v7
 
       - name: Install LLVM ${{ env.LLVM_VERSION }}
         run: |
@@ -63,7 +63,7 @@ jobs:
           lcov --list coverage.info
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@v7
 
       - name: Install LLVM ${{ env.LLVM_VERSION }}
         run: |
@@ -49,7 +49,7 @@ jobs:
             "llvm-${LLVM_VERSION}-dev" "llvm-${LLVM_VERSION}-tools"
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: manual
@@ -60,6 +60,6 @@ jobs:
           cmake --build --preset release --target norac
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,7 +16,7 @@ jobs:
   clang-format:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@v7
 
       - name: Install clang-format ${{ env.LLVM_VERSION }}
         run: |

--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@v7
 
       - name: Install LLVM ${{ env.LLVM_VERSION }}
         run: |
@@ -72,7 +72,7 @@ jobs:
       CC: clang-22
       CXX: clang++-22
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@v7
 
       - name: Install LLVM ${{ env.LLVM_VERSION }}
         run: |


### PR DESCRIPTION
## Summary

Adds `.github/workflows/clang-tidy.yml`, closing the most concrete gap from the
tooling audit in #116: `.clang-tidy` and `CMAKE_EXPORT_COMPILE_COMMANDS=ON` were
already configured, but **no workflow ever ran the linter**, so the ruleset only
affected local editors.

The job:

- Runs on PRs to `main` (paths-filtered to C/C++ sources, `.clang-tidy`, and the
  workflow itself), mirroring the structure of `scan-build.yml`.
- Configures the `debug` preset with `clang-22`/`clang++-22` so the exported
  `compile_commands.json` carries Clang-compatible flags — configuring with GCC
  leaks GCC-only warning options that clang-tidy rejects as
  `unknown-warning-option` errors. Configure alone is enough (it also generates
  `config.h`); no build step is needed for a lint pass.
- Lints **only changed lines** via `clang-tidy-diff.py` (`git diff -U0
  origin/<base>...HEAD`), so the existing ruleset applies to new/modified code
  without drowning PRs in pre-existing findings from unchanged code.
- Uses `-warnings-as-errors='*'` so any finding on a changed line fails the job
  via the script's exit code (verified it respects the line filter — a clean
  changed line in a file with hundreds of pre-existing warnings still passes).

## Scope

#116 is an audit bundling several independent recommendations. This PR
intentionally addresses **only the clang-tidy CI item** so it stays small and
reviewable, hence `Part of #116` rather than a closing keyword — the issue should
remain open for the remaining follow-ups:

- [ ] ccache + FetchContent build caching
- [ ] libFuzzer harness for the lexer/parser (+ ClusterFuzzLite)
- [ ] actionlint + zizmor workflow linting; OpenSSF Scorecard
- [ ] RapidCheck round-trip property tests; Catch2 v2 → v3
- [ ] (optional) mirror the CI lint locally via a `clang-tidy` pre-commit hook

Part of #116

## Test plan

- [x] `cmake --preset debug` (clang) generates `build/debug/compile_commands.json`
- [x] Diff harness validated locally end-to-end against LLVM 22.1.5:
  - clean changed line in a 570-warning file → exit 0
  - changed line with a lint finding → exit 1
  - no C/C++ changes → "No relevant changes found", exit 0
- [x] Simulated the CI step against `origin/main...HEAD` for this PR → no C/C++
  changes, exit 0 (job will be green)

## Also in this PR — action pinning

At the maintainer's request, all workflow `uses:` references are pinned to
release tags instead of commit SHAs (`actions/checkout@v7`,
`github/codeql-action/*@v4`, `codecov/codecov-action@v7`), matching the
`@v7`/`@v1` style already in `claude-code-review.yml`. Dependabot continues to
bump the tags on new releases; the `dependabot.yml` note is updated accordingly.
This trades away the tag-immutability (supply-chain) protection of full-SHA pins.
