### PR TITLE
ci: enforce Conventional Commits (PR titles + commitlint)

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,26 @@
+# Lints commit messages against Conventional Commits on pushes to the default branch.
+# Direct pushes are what the PR-title check can't see; PRs are covered by lint-pr-title.yml.
+name: Lint commits
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v7.0.0
+        with:
+          node-version: lts/*
+      - name: Install commitlint
+        run: npm install --no-save @commitlint/cli@21 @commitlint/config-conventional@21
+      - name: Lint pushed commits
+        if: github.event.before != '0000000000000000000000000000000000000000'
+        run: npx commitlint --from ${{ github.event.before }} --to ${{ github.sha }} --verbose

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -13,11 +13,13 @@ jobs:
   commitlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.0
+      # Tag-pinned, not hash-pinned: this repo's policy is tag pins kept current by
+      # Dependabot rather than SHA pins, so unpinned-uses is a known, accepted tradeoff.
+      - uses: actions/checkout@v7.0.0 # zizmor: ignore[unpinned-uses]
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-node@v7.0.0
+      - uses: actions/setup-node@v7.0.0 # zizmor: ignore[unpinned-uses]
         with:
           node-version: lts/*
       - name: Install commitlint

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -16,11 +16,12 @@ jobs:
       - uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-node@v7.0.0
         with:
           node-version: lts/*
       - name: Install commitlint
-        run: npm install --no-save @commitlint/cli@21 @commitlint/config-conventional@21
+        run: npm install --no-save @commitlint/cli@21 @commitlint/config-conventional@21 # zizmor: ignore[adhoc-packages]
       - name: Lint pushed commits
         if: github.event.before != '0000000000000000000000000000000000000000'
         run: npx commitlint --from ${{ github.event.before }} --to ${{ github.sha }} --verbose

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,23 @@
+# Enforces that PR titles follow the Conventional Commits spec.
+# https://www.conventionalcommits.org/  |  https://github.com/amannn/action-semantic-pull-request
+name: Lint PR title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -2,7 +2,9 @@
 # https://www.conventionalcommits.org/  |  https://github.com/amannn/action-semantic-pull-request
 name: Lint PR title
 
-on:
+# pull_request_target is required so the check also runs on fork PRs. It is safe
+# here: no PR code is checked out and the token is read-only on pull-requests.
+on: # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types:
       - opened

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -20,6 +20,8 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6.1.1
+      # Tag-pinned, not hash-pinned: this repo's policy is tag pins kept current by
+      # Dependabot rather than SHA pins, so unpinned-uses is a known, accepted tradeoff.
+      - uses: amannn/action-semantic-pull-request@v6.1.1 # zizmor: ignore[unpinned-uses]
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,9 @@
 # The extracted Racket expander is a generated artifact and is excluded.
 exclude: '^expander/expander\.rktl$'
 
+# So a plain `pre-commit install` wires up both stages.
+default_install_hook_types: [pre-commit, commit-msg]
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -26,3 +29,9 @@ repos:
     hooks:
       - id: clang-format
         types_or: [c++, c]
+
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.4.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,0 +1,5 @@
+/* Conventional Commits ruleset for commitlint.
+ * .cjs so it loads correctly whether or not the repo's package.json sets "type":"module". */
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+};


### PR DESCRIPTION
Standardizes this repository on [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).

### Adds
- `.github/workflows/lint-pr-title.yml` — validates **PR titles** with [`amannn/action-semantic-pull-request@v6`](https://github.com/amannn/action-semantic-pull-request).
- `.github/workflows/commitlint.yml` — lints **commit messages** on pushes to `main` (covers direct pushes the PR-title check can't see).
- `commitlint.config.cjs` — the Conventional Commits ruleset (`.cjs` so it loads under `"type":"module"` too).
- `.pre-commit-config.yaml` — adds a **local `commit-msg` hook** ([`compilerla/conventional-pre-commit`](https://github.com/compilerla/conventional-pre-commit)) so a bad commit message is rejected at commit time rather than in CI. `default_install_hook_types: [pre-commit, commit-msg]` means the existing `pre-commit install` step wires up both stages — no extra flags needed.

### Notes
- For the PR-title check to feed clean history, enable **Settings → Pull Requests → Allow squash merging** with *"Default to PR title for squash-merge commits"*.
- `commitlint.yml` only lints commits going forward — it does not fail on existing history.
- Contributors who already ran `pre-commit install` should re-run it once to pick up the `commit-msg` stage.
- Both workflows are clean under [`zizmor`](https://docs.zizmor.sh/): `lint-pr-title.yml` carries an inline `ignore[dangerous-triggers]` for its `pull_request_target` trigger (needed so the check runs on fork PRs; safe here since no PR code is checked out and the token is read-only), and `commitlint.yml` drops its unused checkout credentials via `persist-credentials: false` and marks the version-pinned commitlint install as intentional. The `uses:` lines also carry `ignore[unpinned-uses]`: like every other workflow in this repo they are pinned to release tags that Dependabot bumps weekly, rather than to SHAs.

_Part of a cross-repo standardization pass. Review and merge, or close if unwanted._


---

**Note for existing clones:** `default_install_hook_types` only takes effect the next time hooks are (re-)installed — it does not retroactively add `commit-msg` to a `.git/hooks/` that was set up before this PR. If you already ran the setup once, re-run it after this merges:

```
pre-commit install
```

(Flagged by an automated review comment on pmatos/rightkey#646; applies identically here.)
